### PR TITLE
Update fontawesome to version 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for plugin *ce-ui*
 
+## 1.9.4 (To be released)
+
+- BUG: update used icons to fontawesome 6
+
 ## 1.9.3 (2024-11-27)
 
 - BUG: Fixed user permission editor

--- a/ce_ui/templates/403.html
+++ b/ce_ui/templates/403.html
@@ -5,7 +5,7 @@
 
 <div class="card">
  <h3 class="card-header">
-   {% fa5_icon 'flash' %}
+   {% fa6_icon 'bolt' %}
    Access denied.
  </h3>
  <div class="card-body">

--- a/ce_ui/templates/500.html
+++ b/ce_ui/templates/500.html
@@ -4,9 +4,9 @@
 {% block content %}
 
 <div class="card">
- <h3 class="card-header">
-   {% fa5_icon 'flash' %}
-   Server error
+ <h3 class="card-headek">
+   {% fa6_icon 'bolt' %}
+   Sekver error
  </h3>
  <div class="card-body">
    <div class="alert alert-error" role="alert">

--- a/ce_ui/templates/manager/fa6_icon.html
+++ b/ce_ui/templates/manager/fa6_icon.html
@@ -1,2 +1,2 @@
-{# Render an fontawesome 5 icon. See manager/templatetags/icon_tags.py #}
+{# Render an fontawesome 6 icon. See manager/templatetags/icon_tags.py #}
 <i class="{{ classes }}" {% if title %}title="{{ title }}"{% endif %}></i>

--- a/ce_ui/templates/pages/basic_usage.html
+++ b/ce_ui/templates/pages/basic_usage.html
@@ -12,7 +12,7 @@ Thank you.
 
 <ol>
   <li>Visit the
-    <a href="{% url 'ce_ui:select' %}">{% fa5_icon 'check-square' 'far' %} Datasets</a> tab.</li>
+    <a href="{% url 'ce_ui:select' %}">{% fa6_icon 'square-check' 'fa-regular' %} Datasets</a> tab.</li>
   <li>If you want to add a measurement to an existing surface, press its "View" button.
   Otherwise press the "Create surface" button and fill out the form, press "Save".</li>
   <li>The detail page for the surface opens. Press "Add measurement" and follow the dialogue.</li>
@@ -25,21 +25,21 @@ Thank you.
 
 <h3>Comparing analysis results from multiple surfaces/measurements</h3>
 <ol>
-  <li>First visit <a href="{% url 'ce_ui:select' %}">{% fa5_icon 'check-square' 'far' %} Find&Select</a>,
+  <li>First visit <a href="{% url 'ce_ui:select' %}">{% fa6_icon 'square-check' 'fa-regular' %} Find&Select</a>,
   and use the checkboxes to select one or more surface and/or measurements.
     You can see the measurements by clicking on the small triangle
    on the left-hand side of a surface's name. The selected items appear in the bar underneath the
   top navigation bar, which always shows the <em>current selection</em>.</li>
   <li>Next to the current selection a button appears:
     <a class="btn btn-sm btn-outline-success" href="{% url 'ce_ui:results-list' %}">
-      {% fa5_icon 'chart-area' %} Analyze
+      {% fa6_icon 'chart-area' %} Analyze
     </a>
     Press it in order to view analyses for the current selection.
   </li>
-  <li>Another tab opens named <b>{% fa5_icon 'chart-area' %} Analyze</b>.
+  <li>Another tab opens named <b>{% fa6_icon 'chart-area' %} Analyze</b>.
   <li>Select one or more Analysis function by clicking on their checkboxes, e.g. choose
-  {% fa5_icon 'check-square' 'far' %} <em>Height Distribution</em>
-  and {% fa5_icon 'check-square' 'far' %} <em>Power Spectrum</em>.</li>
+  {% fa6_icon 'square-check' 'fa-regular' %} <em>Height Distribution</em>
+  and {% fa6_icon 'square-check' 'fa-regular' %} <em>Power Spectrum</em>.</li>
   <li>Press the button <button class="btn btn-primary btn-sm">Update results</button>.</li>
   <li>For each analysis function a card is shown. You can use the toolbar at the plot to zoom/pan etc. or
   download the plot. Some analysis plots may provide additional feature's. They are accessible
@@ -52,7 +52,7 @@ Thank you.
 If you want to analyze a single surface or measurement, there are also alternative ways:
 
 <ol>
-  <li>First visit the <a href="{% url 'ce_ui:select' %}">{% fa5_icon 'check-square' 'far' %} Find&Select</a> tab, and
+  <li>First visit the <a href="{% url 'ce_ui:select' %}">{% fa6_icon 'square-check' 'fa-regular' %} Find&Select</a> tab, and
   find the surface you are interested in. Press the "Analyze" button on the right-hand side of the row.
   Then automatically, this surface is selected with all of its measurements and
   the "Analyze" tab is loaded. This also works for measurements.</li>
@@ -62,7 +62,7 @@ If you want to analyze a single surface or measurement, there are also alternati
   bandwidth plot or by sweeping through a gallery of measurements and clicking on one thumbnail.
   After the detail page for the measurement has opened, press "Analyze this measurement".
   The old selection is then replaced by this measurement, and the
-    <b>{% fa5_icon 'chart-area' %} Analyze</b>
+    <b>{% fa6_icon 'chart-area' %} Analyze</b>
   tab opens.</li>
 </ol>
 

--- a/ce_ui/templates/tabnav/tabs.html
+++ b/ce_ui/templates/tabnav/tabs.html
@@ -15,7 +15,7 @@
   {% if error %}
     <li class="nav-item">
       <a class="nav-link active">
-        {% fa5_icon 'bolt' %} Error
+        {% fa6_icon 'bolt' %} Error
       </a>
     </li>
   {% endif %}

--- a/ce_ui/templatetags/icon_tags.py
+++ b/ce_ui/templatetags/icon_tags.py
@@ -1,21 +1,22 @@
 """
 Template tags for displaying icons.
 """
+
 from django import template
 
 register = template.Library()
 
 
-@register.inclusion_tag('manager/fa5_icon.html')
-def fa5_icon(name, style_prefix='fas', title=None):
-    """Returns a HMTL snippet which generates an fontawesome 5 icon.
+@register.inclusion_tag("manager/fa6_icon.html")
+def fa6_icon(name, style_prefix="fa-solid", title=None):
+    """Returns a HMTL snippet which generates an fontawesome 6 icon.
 
     Parameters:
 
         style_prefix: str
-            'fas' (default) for solid icons, 'far' for regular icons
+            'fa-solid' (default) for solid icons, 'fa-regular' for regular icons
     """
     return {
-        'classes': f'fa-{name} {style_prefix}',
-        'title': title,
+        "classes": f"fa-{name} {style_prefix}",
+        "title": title,
     }


### PR DESCRIPTION
We currently use fontawesome 6.
The template tag and some of the icon names are still from fontawesome 5.
This PR updates the template tag and all usages of it.