### PR TITLE
Restore crispy_forms for allauth pages; CSRF/delete-URL fixes; sync .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,3 +376,11 @@ static/js/*.woff2
 static/js/*.js
 
 .env
+
+# Shared project data paths (homogenized across ContactEngineering repos)
+data-lake
+topographies
+topobank/analysis/tests/topographies
+
+# Legacy docker-based generated pip packages
+docker/local/django/pip-packages/*

--- a/ce_ui/settings/base.py
+++ b/ce_ui/settings/base.py
@@ -134,6 +134,11 @@ THIRD_PARTY_APPS = [
     "request_profiler",  # keep track of response times for selected routes
     "drf_spectacular",  # API documentation
     "termsandconditions",
+    # Bootstrap 5 rendering for the server-side allauth authentication pages
+    # (login/signup/password management). The main UI is Vue, but allauth forms
+    # are rendered by Django and rely on the crispy_forms_tags template library.
+    "crispy_forms",
+    "crispy_bootstrap5",
 ]
 LOCAL_APPS = [
     # Your stuff: custom apps go here
@@ -154,6 +159,11 @@ LOCAL_APPS = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 # Remove duplicate entries
 INSTALLED_APPS = list(set(DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS))
+
+# CRISPY FORMS (Bootstrap 5 template pack for server-rendered allauth pages)
+# ------------------------------------------------------------------------------
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
+CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 # MIGRATIONS
 # ------------------------------------------------------------------------------

--- a/ce_ui/tests/conftest.py
+++ b/ce_ui/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 from topobank.testing.factories import OrganizationFactory  # noqa: F401
 from topobank.testing.factories import UserFactory
-from topobank.testing.fixtures import sync_workflows  # noqa: F401
 from topobank.testing.fixtures import test_workflow  # noqa: F401
 from topobank.testing.fixtures import two_topos  # noqa: F401
 from topobank.testing.fixtures import (  # noqa: F401

--- a/frontend/app.ts
+++ b/frontend/app.ts
@@ -15,6 +15,18 @@ import {registerAnalysisCardComponents} from "./analysis/index";
 // Import the AppFrame component
 import AppFrame from './apps/AppFrame.vue';
 
+function getCookie(name: string) {
+    const cookie = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith(`${name}=`));
+
+    if (cookie === undefined) {
+        return null;
+    }
+
+    return decodeURIComponent(cookie.split('=').slice(1).join('='));
+}
+
 /**
  * Create Vue.js app for a component and hook it up to DOM element
  */
@@ -24,7 +36,21 @@ export function createAppFrame(element, csrfToken, appProps, componentProps) {
     pinia.use(piniaPluginPersistedstate);
     app.use(pinia);
     app.use(createBootstrap());
+    axios.defaults.xsrfCookieName = 'csrftoken';
+    axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+    axios.defaults.withXSRFToken = true;
     axios.defaults.headers.common['X-CSRFToken'] = csrfToken;
+    axios.interceptors.request.use((config) => {
+        const tokenFromCookie = getCookie('csrftoken');
+        const token = tokenFromCookie ?? csrfToken;
+
+        if (token !== null && token !== undefined && token !== '') {
+            config.headers = config.headers ?? {};
+            config.headers['X-CSRFToken'] = token;
+        }
+
+        return config;
+    });
     app.provide('csrfToken', csrfToken);
     app.provide('appProps', appProps);
     // Register all single-page components from the index

--- a/frontend/manager/TopographyErrorCard.vue
+++ b/frontend/manager/TopographyErrorCard.vue
@@ -17,20 +17,25 @@ export default {
         topography: {
             type: Object,
             default: null
+        },
+        topographyUrl: {
+            type: String,
+            default: null
         }
     },
     methods: {
         deleteTopography() {
-            axios.delete(this.topography.url);
-            this.$emit('delete:topography', this.topography.url);
+            axios.delete(this.topographyUrl).then(() => {
+                this.$emit('delete:topography', this.topographyUrl);
+            });
         },
         forceInspect() {
-            axios.post(`${this.topography.url}force-inspect/`).then(response => {
+            axios.post(`${this.topographyUrl}force-inspect/`).then(response => {
                 this.$emit('update:topography', response.data);
             });
         },
         dataSourceChanged(value) {
-            axios.patch(this.topography.url, {'data_source': this.topography.data_source}).then(response => {
+            axios.patch(this.topographyUrl, {'data_source': this.topography.data_source}).then(response => {
                 this.$emit('update:topography', response.data);
             });
         }


### PR DESCRIPTION
The move to per-page Vue apps dropped `crispy_forms` from `INSTALLED_APPS`, but the server-rendered allauth pages (login/signup/password) and the user profile form still load `crispy_forms_tags` — so those pages returned HTTP 500. Re-add `crispy_forms` + `crispy_bootstrap5` and set the bootstrap5 template pack.

Also:
- Drop the import of topobank's removed `sync_workflows` test fixture.
- Forward the CSRF token from the cookie on all axios requests; pass an explicit `topographyUrl` prop to `TopographyErrorCard`.
- Homogenize `.gitignore` with the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)