### PR TITLE
BUG: Fix user search modal (wrong endpoint + paginated response)

### DIFF
--- a/frontend/components/SearchUserModal.vue
+++ b/frontend/components/SearchUserModal.vue
@@ -19,7 +19,7 @@ export default {
     props: {
         url: {
             type: String,
-            default: '/users/api/user/'
+            default: '/users/v1/user/'
         },
         maxResults: {
             type: Number,
@@ -37,8 +37,8 @@ export default {
     },
     methods: {
         searchUser(searchTerm) {
-            axios.get(`${this.url}?name=${searchTerm}&max=${this.maxResults}`).then(response => {
-                this._searchResult = response.data;
+            axios.get(`${this.url}?name=${searchTerm}&limit=${this.maxResults}`).then(response => {
+                this._searchResult = response.data.results;
             });
         },
         selectUser(user) {


### PR DESCRIPTION
The user-search modal (`SearchUserModal.vue`, used by `DatasetPermissions.vue`) showed no users.

**Cause:** it queried `/users/api/user/`, but the users API was migrated to the `v1/` version segment (`/users/v1/user/`) — so the request 404'd. (The `manager`/`analysis` apps still use `api/`, which is why only user search broke.)

**Fix:**
- Default endpoint `/users/api/user/` → `/users/v1/user/`.
- `UserViewSet` uses `LimitOffsetPagination`, so the response is `{count, results, …}` — read `response.data.results` instead of the whole object.
- Use `limit` (the pagination param) instead of the ignored `max` so `maxResults` actually caps results.

The `name` query param and displayed fields (`user.name`, `user.orcid`) were already correct.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)