### PR TITLE
ENH: Reintroduce supported file formats overview page

### DIFF
--- a/ce_ui/templates/pages/file_formats.html
+++ b/ce_ui/templates/pages/file_formats.html
@@ -1,0 +1,47 @@
+{% extends "app.html" %}
+{% load static i18n %}
+
+{% block appcontent %}
+    <div class="container mt-3">
+        <h1>Supported file formats</h1>
+
+        <p>
+            Extending the list of supported file formats is a continuous work in
+            progress. If your file is not supported, if you have a question or a
+            problem uploading topography data, or if you need more information,
+            please
+            <a href="https://github.com/ContactEngineering/TopoBank/issues"
+               target="_blank" rel="noopener">open an issue on GitHub</a>.
+            Thank you for your help!
+        </p>
+
+        <p>
+            The following file formats are supported. Click on a format name to
+            expand its description.
+        </p>
+
+        <div class="accordion" id="file-formats">
+            {% for name, format, description in reader_infos %}
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#collapse-format-{{ forloop.counter }}"
+                                aria-expanded="false"
+                                aria-controls="collapse-format-{{ forloop.counter }}">
+                            <span class="me-auto">{{ name }}</span>
+                            <span class="badge bg-secondary">{{ format }}</span>
+                        </button>
+                    </h2>
+                    <div id="collapse-format-{{ forloop.counter }}"
+                         class="accordion-collapse collapse"
+                         data-bs-parent="#file-formats">
+                        <div class="accordion-body">
+                            {{ description|safe }}
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock appcontent %}

--- a/ce_ui/urls.py
+++ b/ce_ui/urls.py
@@ -51,6 +51,11 @@ urlpatterns = [
         name="terms",
     ),
     path(
+        "file-formats/",
+        views.FileFormatsView.as_view(),
+        name="file-formats",
+    ),
+    path(
         "search/",
         RedirectView.as_view(pattern_name="ce_ui:select"),
         name="search",

--- a/ce_ui/views.py
+++ b/ce_ui/views.py
@@ -16,7 +16,8 @@ from termsandconditions.views import (AcceptTermsView, GetTermsViewMixin,
 from topobank.analysis.models import Workflow
 from topobank.analysis.registry import get_workflow_names
 from topobank.manager.models import Surface, Topography
-from topobank.manager.utils import subjects_from_base64, subjects_to_base64
+from topobank.manager.utils import (get_reader_infos, subjects_from_base64,
+                                    subjects_to_base64)
 from topobank_orcid.users.models import User
 from topobank_publication.models import PublicationCollection
 from topobank_publication.serializers import PublicationCollectionSerializer
@@ -363,6 +364,30 @@ class AnalysisListView(AppView):
 
 class HomeView(AppView):
     vue_component = "Home"
+
+
+class FileFormatsView(AppView):
+    """Overview of the file formats supported for topography upload.
+
+    The list is generated dynamically from the SurfaceTopography reader
+    registry, so it stays up to date as new readers are added.
+    """
+
+    template_name = "pages/file_formats.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["reader_infos"] = get_reader_infos()
+        context["extra_tabs"] = [
+            {
+                "icon": "file",
+                "title": "Supported file formats",
+                "href": self.request.path,
+                "active": True,
+                "login_required": False,
+            }
+        ]
+        return context
 
 
 class TermsListView(TemplateView, GetTermsViewMixin):

--- a/frontend/base/UserMenuOffcanvas.vue
+++ b/frontend/base/UserMenuOffcanvas.vue
@@ -51,6 +51,7 @@ const contactModal = ref(false);
             <BNavItem href="/watchman/">Watchman status (JSON)</BNavItem>
         </BNavbarNav>
         <BNavbarNav class="p-3 justify-content-end flex-grow-1">
+            <BNavItem href="/file-formats/">Supported file formats</BNavItem>
             <BNavItem href="/termsandconditions/">Terms &amp; conditions</BNavItem>
             <BNavItem href="https://github.com/ContactEngineering/TopoBank/discussions">
                 Feedback


### PR DESCRIPTION
Reintroduces the 'Supported file formats' help page (removed in 5d6f861, issue #242).

The list is generated **dynamically** from the SurfaceTopography reader registry via `get_reader_infos()` (still present in `topobank.manager.utils`), so it never goes stale — 39 formats today (SDF, XYZ, Bruker/Veeco DI, Gwyddion, NetCDF, HDF5, Zygo, …).

- `FileFormatsView` renders `pages/file_formats.html` (extends `app.html`) at `/file-formats/`.
- Accordion modernized from the old Bootstrap 4 markup to Bootstrap 5.
- Added a 'Supported file formats' link to the user-menu offcanvas.

Verified: `manage.py check` clean; `get_reader_infos()` returns 39 readers; the template compiles and renders all 39 items.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)