### PR TITLE
Fix ce-ui CI: plugin dependency resolution + adapt analysis tests to Workflow-model removal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,12 @@ jobs:
       run: |
         pip install --upgrade pip pip-tools
         pip install \
-          git+https://github.com/ContactEngineering/topobank.git \
-          git+https://github.com/ContactEngineering/topobank-rest-api.git \
-          git+https://github.com/ContactEngineering/topobank-statistics.git \
-          git+https://github.com/ContactEngineering/topobank-contact.git \
-          git+https://github.com/ContactEngineering/topobank-publication.git \
-          git+https://github.com/ContactEngineering/topobank-orcid.git \
+          git+https://github.com/ContactEngineering/topobank.git@main \
+          git+https://github.com/ContactEngineering/topobank-rest-api.git@main \
+          git+https://github.com/ContactEngineering/topobank-statistics.git@main \
+          git+https://github.com/ContactEngineering/topobank-contact.git@main \
+          git+https://github.com/ContactEngineering/topobank-publication.git@main \
+          git+https://github.com/ContactEngineering/topobank-orcid.git@main \
           .[dev]
 
     - name: Test

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,18 @@
 pytest_plugins = ["topobank.testing.fixtures"]
+
+# Register topobank's test workflow implementations so the analysis tests can
+# resolve them from the registry. register_implementation is idempotent (keyed
+# by name), so registering here in addition to anywhere else is harmless.
+from topobank.analysis.registry import register_implementation  # noqa: E402
+from topobank.testing.workflows import (  # noqa: E402
+    SecondTestImplementation, TestImplementation, TestImplementationWithError,
+    TestImplementationWithErrorInDependency, TopographyOnlyTestImplementation)
+
+for _implementation in (
+    TestImplementation,
+    SecondTestImplementation,
+    TestImplementationWithError,
+    TestImplementationWithErrorInDependency,
+    TopographyOnlyTestImplementation,
+):
+    register_implementation(_implementation)

--- a/tests/analysis/test_cards.py
+++ b/tests/analysis/test_cards.py
@@ -20,12 +20,12 @@ def test_series_card_data_sources(api_client, handle_usage_statistics):
     password = "secret"
     user = UserFactory(password=password)
     surface = SurfaceFactory(created_by=user)
-    func1 = Workflow.objects.get(name="topobank.testing.test")
+    func1 = Workflow(name="topobank.testing.test")
 
     topo1 = Topography2DFactory(surface=surface)
 
     analysis = TopographyAnalysisFactory(
-        subject_topography=topo1, function=func1, user=user
+        subject_topography=topo1, workflow_name=func1.name, user=user
     )
 
     #
@@ -101,7 +101,7 @@ def test_series_card_if_no_successful_topo_analysis(
     user = UserFactory(password=password)
     ContentType.objects.get_for_model(Topography)
     ContentType.objects.get_for_model(Surface)
-    func1 = Workflow.objects.get(name="topobank.testing.test")
+    func1 = Workflow(name="topobank.testing.test")
 
     surf = SurfaceFactory(created_by=user)
     topo = Topography1DFactory(surface=surf)  # also generates the surface
@@ -110,7 +110,7 @@ def test_series_card_if_no_successful_topo_analysis(
     SurfaceAnalysisFactory(
         task_state="su",
         subject_surface_id=topo.surface.id,
-        function=func1,
+        workflow_name=func1.name,
         user=user,
     )
 
@@ -118,25 +118,25 @@ def test_series_card_if_no_successful_topo_analysis(
     TopographyAnalysisFactory(
         task_state="fa",
         subject_topography_id=topo.id,
-        function=func1,
+        workflow_name=func1.name,
         user=user,
     )
 
     assert (
         WorkflowResult.objects.filter(
-            function=func1, subject_topography_id=topo.id, task_state="su"
+            workflow_name=func1.name, subject_topography_id=topo.id, task_state="su"
         ).count()
         == 0
     )
     assert (
         WorkflowResult.objects.filter(
-            function=func1, subject_topography_id=topo.id, task_state="fa"
+            workflow_name=func1.name, subject_topography_id=topo.id, task_state="fa"
         ).count()
         == 1
     )
     assert (
         WorkflowResult.objects.filter(
-            function=func1,
+            workflow_name=func1.name,
             subject_surface_id=topo.surface.id,
             task_state="su",
         ).count()

--- a/tests/analysis/test_dependencies.py
+++ b/tests/analysis/test_dependencies.py
@@ -1,13 +1,13 @@
 import celery.states
 import pytest
-from topobank_rest_api.utils import get_api_url
 from django.test import override_settings
 from rest_framework.reverse import reverse
-
 from topobank.analysis.models import Workflow, WorkflowResult
 from topobank.analysis.tasks import schedule_workflow
 from topobank.manager.utils import dict_to_base64, subjects_to_base64
-from topobank.testing.factories import SurfaceFactory, Topography1DFactory, UserFactory
+from topobank.testing.factories import (SurfaceFactory, Topography1DFactory,
+                                        UserFactory)
+from topobank_rest_api.utils import get_api_url
 
 
 @pytest.mark.django_db
@@ -18,7 +18,7 @@ def test_dependencies(api_client, django_capture_on_commit_callbacks):
     surface = SurfaceFactory(created_by=user)
     topo1 = Topography1DFactory(surface=surface)
 
-    func = Workflow.objects.get(name="topobank.testing.test2")
+    func = Workflow(name="topobank.testing.test2")
 
     api_client.force_login(user)
 
@@ -39,7 +39,7 @@ def test_dependencies(api_client, django_capture_on_commit_callbacks):
     # New Analysis objects should be there and marked for the user
     #
     assert WorkflowResult.objects.count() == 3
-    test_ana1, test_ana2, test2_ana = WorkflowResult.objects.all().order_by("function__name")
+    test_ana1, test_ana2, test2_ana = WorkflowResult.objects.all().order_by("workflow_name")
     assert test2_ana.function.name == "topobank.testing.test2"
     assert test_ana1.function.name == "topobank.testing.test"
     assert test_ana2.function.name == "topobank.testing.test"
@@ -67,7 +67,7 @@ def test_dependency_status():
     surface = SurfaceFactory(created_by=user)
     topo1 = Topography1DFactory(surface=surface)
 
-    func = Workflow.objects.get(name="topobank.testing.test2")
+    func = Workflow(name="topobank.testing.test2")
 
     kwargs = {"c": 33, "d": 7.5}
     analysis = func.submit(user, topo1, kwargs)
@@ -79,7 +79,7 @@ def test_dependency_status():
     # New Analysis objects should be there and marked for the user
     #
     assert WorkflowResult.objects.count() == 3
-    test_ana1, test_ana2, test2_ana = WorkflowResult.objects.all().order_by("function__name")
+    test_ana1, test_ana2, test2_ana = WorkflowResult.objects.all().order_by("workflow_name")
     assert test2_ana.function.name == "topobank.testing.test2"
     assert test_ana1.function.name == "topobank.testing.test"
     assert test_ana2.function.name == "topobank.testing.test"
@@ -113,7 +113,7 @@ def test_error_propagation(
     surface = SurfaceFactory(created_by=user)
     topo1 = Topography1DFactory(surface=surface)
 
-    func = Workflow.objects.get(
+    func = Workflow(
         name="topobank.testing.test_error_in_dependency"
     )
 
@@ -129,7 +129,7 @@ def test_error_propagation(
     # New Analysis objects should be there and marked for the user
     #
     assert WorkflowResult.objects.count() == 2
-    test_ana1, test_ana2 = WorkflowResult.objects.all().order_by("function__name")
+    test_ana1, test_ana2 = WorkflowResult.objects.all().order_by("workflow_name")
     assert test_ana1.function.name == "topobank.testing.test_error"
     assert test_ana2.function.name == "topobank.testing.test_error_in_dependency"
     assert test_ana1.dependencies == {}
@@ -172,7 +172,7 @@ def test_integer_key_dependencies(api_client, django_capture_on_commit_callbacks
     surface = SurfaceFactory(created_by=user)
     topo1 = Topography1DFactory(surface=surface)
 
-    func = Workflow.objects.get(name="topobank.testing.test_integer_keys")
+    func = Workflow(name="topobank.testing.test_integer_keys")
 
     api_client.force_login(user)
 
@@ -193,7 +193,7 @@ def test_integer_key_dependencies(api_client, django_capture_on_commit_callbacks
     assert WorkflowResult.objects.count() == 2
 
     # Find the main analysis (the one with integer key dependencies)
-    main_ana = WorkflowResult.objects.get(function__name="topobank.testing.test_integer_keys")
+    main_ana = WorkflowResult.objects.get(workflow_name="topobank.testing.test_integer_keys")
 
     # Verify the workflow completed successfully
     # If integer keys are not handled correctly, this will fail with:

--- a/tests/analysis/test_recalculate.py
+++ b/tests/analysis/test_recalculate.py
@@ -18,8 +18,8 @@ def test_refresh_analyses_api(
 
     func = test_workflow
 
-    analysis1a = TopographyAnalysisFactory(subject_topography=topo1, function=func)
-    analysis2a = TopographyAnalysisFactory(subject_topography=topo2, function=func)
+    analysis1a = TopographyAnalysisFactory(subject_topography=topo1, workflow_name=func.name)
+    analysis2a = TopographyAnalysisFactory(subject_topography=topo2, workflow_name=func.name)
 
     api_client.force_login(user)
 
@@ -42,8 +42,8 @@ def test_refresh_analyses_api(
     #
     # New Analysis objects should be there and marked for the user
     #
-    analysis1b = WorkflowResult.objects.get(function=func, subject_topography=topo1)
-    analysis2b = WorkflowResult.objects.get(function=func, subject_topography=topo2)
+    analysis1b = WorkflowResult.objects.get(workflow_name=func.name, subject_topography=topo1)
+    analysis2b = WorkflowResult.objects.get(workflow_name=func.name, subject_topography=topo2)
 
     assert analysis1b.has_permission(user, "view")
     assert analysis2b.has_permission(user, "view")


### PR DESCRIPTION
The `tests (3.10)` job was fully red. Two independent causes, both fixed here:

**1. Install failed with `ResolutionImpossible` (no tests ran).**
pip treats a bare `git+URL` and `git+URL@main` as conflicting direct references. `topobank-statistics` pins `topobank-rest-api @ git+…@main`, but the workflow installed rest-api via a bare URL. Fix: reference all ContactEngineering plugins explicitly at `@main`.

**2. Once install worked, 6 analysis tests failed** against the current topobank (Workflow DB model removed; `WorkflowResult.function` is now a read-only property backed by `workflow_name`). Fix in `tests/analysis/`:
- `Workflow.objects.get(name=…)` → `Workflow(name=…)`
- `function=` (factory/create/query) → `workflow_name=`; `function__name` order_by/lookup → `workflow_name`
- register topobank's test workflow implementations in the root `conftest.py` so the top-level `tests/` package can resolve them (idempotent)

Verified locally: full ce-ui suite **24 passed, 3 skipped**.

> This was pre-existing on `main` (masked by the install failure). Merging this unblocks CI; the other open ce-ui PRs (#246, #247, #250) will pass once rebased on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)