### PR TITLE
BUG: Harden settings and fix backend/frontend audit findings

### DIFF
--- a/ce_ui/asgi.py
+++ b/ce_ui/asgi.py
@@ -8,6 +8,7 @@ https://docs.djangoproject.com/en/dev/howto/deployment/asgi/
 
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -17,6 +18,9 @@ from django.core.asgi import get_asgi_application
 # ce_ui directory.
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 sys.path.append(str(BASE_DIR / "ce_ui"))
+
+# We defer to a DJANGO_SETTINGS_MODULE already in the environment.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ce_ui.settings.production")
 
 # This application object is used by any ASGI server configured to use this file.
 django_application = get_asgi_application()

--- a/ce_ui/management/commands/import_terms.py
+++ b/ce_ui/management/commands/import_terms.py
@@ -1,18 +1,17 @@
+import argparse
+import datetime
+import decimal
+
+import markdown2
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from django.utils.html import escape
-
-import datetime
-import argparse
-import decimal
-import markdown2
-
 from termsandconditions.models import TermsAndConditions
 
 
 def valid_date(s):
     try:
-        return datetime.strptime(s, "%Y-%m-%d")
+        return datetime.datetime.strptime(s, "%Y-%m-%d")
     except ValueError:
         msg = "Not a valid date: '{0}'.".format(s)
         raise argparse.ArgumentTypeError(msg)

--- a/ce_ui/settings/base.py
+++ b/ce_ui/settings/base.py
@@ -158,7 +158,7 @@ LOCAL_APPS = [
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 # Remove duplicate entries
-INSTALLED_APPS = list(set(DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS))
+INSTALLED_APPS = list(dict.fromkeys(DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS))
 
 # CRISPY FORMS (Bootstrap 5 template pack for server-rendered allauth pages)
 # ------------------------------------------------------------------------------
@@ -441,10 +441,8 @@ AWS_S3_FILE_OVERWRITE = False
 STATIC_ROOT = env.str(
     "DJANGO_STATIC_ROOT", default=(APPS_DIR - 2).path("staticfiles")
 )  # This is not used in the development environment
-print(f"STATIC_ROOT: {STATIC_ROOT}")
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = "/static/"
-print(f"STATIC_URL: {STATIC_URL}")
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIR = env.str("DJANGO_STATICFILES_DIR", default=None)
 # The /static dir of each app is searched automatically, we here add one auxiliary directory
@@ -452,7 +450,6 @@ if STATICFILES_DIR is None:
     STATICFILES_DIRS = []
 else:
     STATICFILES_DIRS = [STATICFILES_DIR]
-print(f"STATICFILES_DIRS: {STATICFILES_DIRS}")
 
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders
 STATICFILES_FINDERS = [
@@ -709,5 +706,5 @@ TOPOBANK_DELETE_DELAY = timedelta(days=7)  # Hold deleted datasets this long
 # ALLAUTH SETTINGS
 # ------------------------------------------------------------------------------
 ACCOUNT_SIGNUP_FIELDS = ['email', 'username*', 'password1*', 'password2*']
-USER_MODEL_USERNAME_FIELD = "username"
-USERNAME_MIN_LENGTH = 3
+ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
+ACCOUNT_USERNAME_MIN_LENGTH = 3

--- a/ce_ui/settings/production.py
+++ b/ce_ui/settings/production.py
@@ -4,9 +4,13 @@ from .base import env
 # GENERAL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
-SECRET_KEY = env("DJANGO_SECRET_KEY", default=random_string())  # noqa: F405
+SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["example.com"])
+
+# https://docs.djangoproject.com/en/dev/ref/settings/#debug
+# Never run with debug turned on in production.
+DEBUG = False
 
 # DATABASES
 # ------------------------------------------------------------------------------
@@ -75,7 +79,7 @@ EMAIL_SUBJECT_PREFIX = env(
 # ADMIN
 # ------------------------------------------------------------------------------
 # Django Admin URL regex.
-ADMIN_URL = env("DJANGO_ADMIN_URL", default=random_string())  # noqa: F405
+ADMIN_URL = env("DJANGO_ADMIN_URL")
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 

--- a/ce_ui/settings/test.py
+++ b/ce_ui/settings/test.py
@@ -139,9 +139,6 @@ STORAGES = {
     "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
 }
 
-print(f"STORAGES: {STORAGES}")
-print(f"USE_S3_STORAGE: {USE_S3_STORAGE}")
-
 # URL of the SPA (not used in testing)
 WEBAPP_URL = "http://localhost:5173/"
 TESTING_WEBAPP_URL = "http://localhost:5173/"

--- a/ce_ui/tests/test_prevent_url_guessing.py
+++ b/ce_ui/tests/test_prevent_url_guessing.py
@@ -1,11 +1,11 @@
 import pytest
 from django.contrib.auth.models import Permission
 from django.urls import reverse
-# from topobank.testing.utils import are_collaborating
 from topobank.testing.factories import SurfaceFactory
 
+from ce_ui.views import _users_share_dataset
 
-@pytest.mark.skip("FIXME! Reimplement are_collaborating")
+
 @pytest.mark.django_db
 def test_sharing_profile(client, django_user_model, handle_usage_statistics):
     user1 = django_user_model.objects.create_user(username='testuser1', password="abcd$1234")
@@ -18,21 +18,21 @@ def test_sharing_profile(client, django_user_model, handle_usage_statistics):
 
     assert client.login(username='testuser1', password='abcd$1234')
 
-    response = client.get(reverse('users:detail', kwargs={'username': 'testuser1'}))  # same user
+    response = client.get(reverse('ce_ui:user-detail', kwargs={'username': 'testuser1'}))  # same user
     assert response.status_code == 200
 
     #
     # both users don't share anything, so they can't see each others profiles
     #
-    # assert not are_collaborating(user1, user2)
+    assert not _users_share_dataset(user1, user2)
 
-    response = client.get(reverse('users:detail', kwargs={'username': 'testuser2'}))  # other user!!
+    response = client.get(reverse('ce_ui:user-detail', kwargs={'username': 'testuser2'}))  # other user!!
     assert response.status_code == 403  # Forbidden
 
     # share sth. and the view of profile is possible
-    surface = SurfaceFactory(creator=user1)
-    surface.share(user2)
+    surface = SurfaceFactory(created_by=user1)
+    surface.permissions.grant_for_user(user2, "view")
 
-    # assert are_collaborating(user1, user2)
-    response = client.get(reverse('users:detail', kwargs={'username': 'testuser2'}))
+    assert _users_share_dataset(user1, user2)
+    response = client.get(reverse('ce_ui:user-detail', kwargs={'username': 'testuser2'}))
     assert response.status_code == 200  # Allowed

--- a/ce_ui/views.py
+++ b/ce_ui/views.py
@@ -285,6 +285,23 @@ def extra_tabs_if_single_item_selected(context, subjects):
         )
 
 
+def _safe_subjects_from_request(request):
+    """Decode the ``subjects`` GET parameter without ever raising.
+
+    Returns an empty list when the parameter is missing/empty or cannot be
+    decoded (e.g. malformed base64 or JSON), instead of bubbling up an
+    AttributeError / binascii.Error / JSONDecodeError as a 500 error.
+    """
+    encoded = request.GET.get("subjects")
+    if not encoded:
+        return []
+    try:
+        return subjects_from_base64(encoded, user=request.user)
+    except Exception:
+        _log.warning("Could not decode 'subjects' parameter %r; ignoring.", encoded)
+        return []
+
+
 class AnalysisDetailView(AppDetailView):
     model = Workflow
     slug_field = "name"
@@ -300,9 +317,7 @@ class AnalysisDetailView(AppDetailView):
             raise PermissionDenied()
 
         # Decide whether to open extra tabs for surface/topography details
-        subjects = subjects_from_base64(
-            self.request.GET.get("subjects"), user=self.request.user
-        )
+        subjects = _safe_subjects_from_request(self.request)
         extra_tabs_if_single_item_selected(context, subjects)
         subjects = subjects_to_base64(subjects)
         breadcrumb.add_generic(
@@ -338,9 +353,7 @@ class AnalysisListView(AppView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        subjects = subjects_from_base64(
-            self.request.GET.get("subjects"), user=self.request.user
-        )
+        subjects = _safe_subjects_from_request(self.request)
         extra_tabs_if_single_item_selected(context, subjects)
 
         # Decide whether to open extra tabs for surface/topography details
@@ -496,6 +509,21 @@ class TabbedEmailView(EmailView):
         return context
 
 
+def _users_share_dataset(user_a, user_b):
+    """Return True if both users can view at least one common surface (dataset).
+
+    Two users are considered collaborating when there is at least one surface
+    that both of them are allowed to view (via user or organization
+    permissions). No reusable ``are_collaborating`` helper exists in topobank
+    core, so we implement the check here using the authorization-aware
+    ``Surface.objects.for_user`` queryset.
+    """
+    surfaces_a = set(Surface.objects.for_user(user_a).values_list("pk", flat=True))
+    if not surfaces_a:
+        return False
+    return Surface.objects.for_user(user_b).filter(pk__in=surfaces_a).exists()
+
+
 class UserDetailView(LoginRequiredMixin, DetailView):
     model = User
     # These next two lines tell the view to index lookups by username
@@ -503,7 +531,17 @@ class UserDetailView(LoginRequiredMixin, DetailView):
     slug_url_kwarg = "username"
 
     def dispatch(self, request, *args, **kwargs):
-        # FIXME! Raise permission denied error if the two users have no shared datasets
+        # Users may view their own profile, and the profile of anyone they
+        # collaborate with (i.e. share at least one dataset with). Otherwise
+        # deny access so profiles cannot be enumerated by guessing usernames.
+        if request.user.is_authenticated:
+            target_user = self.get_object()
+            if request.user != target_user and not _users_share_dataset(
+                request.user, target_user
+            ):
+                raise PermissionDenied(
+                    "You may only view the profile of users you share a dataset with."
+                )
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/ce_ui/wsgi.py
+++ b/ce_ui/wsgi.py
@@ -8,7 +8,7 @@ import sys
 from django.core.wsgi import get_wsgi_application
 
 # If we are running without DJANGO_DEBUG, then topobank has been installed via pip
-if os.environ.get("DJANGO_DEBUG", default=False):
+if os.environ.get("DJANGO_DEBUG", "").lower() in ("1", "true", "yes", "on"):
     # This allows easy placement of apps within the interior
     # ce_ui directory when running in debug mode.
     app_path = os.path.abspath(

--- a/frontend/analysis/RoughnessParametersCard.vue
+++ b/frontend/analysis/RoughnessParametersCard.vue
@@ -40,6 +40,16 @@ const props = defineProps({
     },
 });
 
+// Escape a string for safe interpolation into HTML (text content and attribute values).
+function escapeHtml(value) {
+    return String(value == null ? "" : value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
 // Displayed data
 const _analyses = ref(null);
 const _columnDefs = ref([
@@ -51,8 +61,11 @@ const _columns = ref([
     {
         title: "Measurement",
         render: function(data, type, row) {
-            let name = row.topography_name;
-            return `<a target="_blank" title="${name}" href="${row.topography_url}">${name}</a>`;
+            // `topography_name` and `topography_url` are user-controlled and must be escaped to prevent XSS.
+            const name = escapeHtml(row.topography_name);
+            // Encode the URL and escape it for safe use inside the attribute value.
+            const url = escapeHtml(encodeURI(row.topography_url == null ? "" : row.topography_url));
+            return `<a target="_blank" title="${name}" href="${url}">${name}</a>`;
         }
     },
     { data: "quantity", title: "Quantity" },
@@ -79,7 +92,7 @@ onMounted(() => {
 });
 
 const analysisIds = computed(() => {
-    return _analyses.value.map(a => a.id).join();
+    return _analyses.value?.map(a => a.id).join() ?? [];
 });
 
 function updateCard() {

--- a/frontend/analysis/TasksButton.vue
+++ b/frontend/analysis/TasksButton.vue
@@ -21,6 +21,9 @@ const _modalVisible = ref(false);
 let _lastNbRunningOrPending = null;
 const nbRunningOrPending = computed(() => {
     const currentNbRunningOrPending = countTaskStates(analyses.value, ['pe', 'st', 're']);
+    // FIXME: side-effect (emit) inside a computed getter. Emitting events from a computed getter is fragile —
+    // the getter runs on every dependency read/re-evaluation, so events fire at unpredictable times. This should
+    // be refactored to a watcher, but that is a higher-risk change handled in a separate pass.
     // Emit event when all tasks are finished
     if (_lastNbRunningOrPending !== null && _lastNbRunningOrPending > 0) {
         if (currentNbRunningOrPending === 0) {

--- a/frontend/apps/DatasetDetail.vue
+++ b/frontend/apps/DatasetDetail.vue
@@ -538,7 +538,7 @@ const batchActiveTab = ref('home'); // shared active tab for batch mode
                             Publish
                         </a>
 
-                        <a v-if="_versions == null || _versions.length === 0 && hasFullAccess"
+                        <a v-if="(_versions == null || _versions.length === 0) && hasFullAccess"
                            class="btn btn-danger mb-2"
                            href="#" @click="_showDeleteModal = true">
                             Delete

--- a/frontend/apps/DatasetList.vue
+++ b/frontend/apps/DatasetList.vue
@@ -2,7 +2,7 @@
 
 import axios from "axios";
 
-import {computed, onMounted, ref} from "vue";
+import {computed, onBeforeUnmount, onMounted, ref} from "vue";
 
 import {
     BButton,
@@ -81,17 +81,26 @@ const _previousUrl = ref(null);
 
 let searchDelayTimer = null;
 
+// Sequence token to discard stale (out-of-order) responses
+let _requestSequence = 0;
+
 function getDatasets(offset: number = 0) {
     searchDelayTimer = null;
+    // Capture the token for this request; responses from superseded requests are ignored.
+    const requestId = ++_requestSequence;
     _isLoading.value = true;
     _currentPage.value = offset / _pageSize.value + 1;
     let queryUrl = `${props.apiUrl}?offset=${offset}&limit=${_pageSize.value}`;
     queryUrl += `&order_by=${_orderBy.value}`;
     queryUrl += `&sharing_status=${_sharingStatus.value}`;
-    if (_searchTerm != null) {
-        queryUrl += `&search=${_searchTerm.value}`;
+    if (_searchTerm.value != null) {
+        queryUrl += `&search=${encodeURIComponent(_searchTerm.value)}`;
     }
     axios.get(queryUrl).then(response => {
+        // Ignore this response if a newer request has been issued in the meantime
+        if (requestId !== _requestSequence) {
+            return;
+        }
         _nbDatasets.value = response.data.count;
         _nbDatasetsOnCurrentPage.value = Math.min(response.data.results.length, _pageSize.value);
         _nextUrl.value = response.data.next;
@@ -99,6 +108,9 @@ function getDatasets(offset: number = 0) {
         _datasets.value = response.data.results;
         _isLoading.value = false;
     }).catch(error => {
+        if (requestId !== _requestSequence) {
+            return;
+        }
         show?.({
             props: {
                 title: "Error fetching datasets",
@@ -112,6 +124,13 @@ function getDatasets(offset: number = 0) {
 
 onMounted(() => {
     getDatasets();
+});
+
+onBeforeUnmount(() => {
+    if (searchDelayTimer != null) {
+        clearTimeout(searchDelayTimer);
+        searchDelayTimer = null;
+    }
 });
 
 const currentPage = computed({

--- a/frontend/apps/TopographyDetail.vue
+++ b/frontend/apps/TopographyDetail.vue
@@ -33,6 +33,8 @@ const props = defineProps({
     }
 });
 
+const emit = defineEmits(["topography-deleted"]);
+
 const appProps = inject("appProps");
 
 const _disabled = ref(false);
@@ -61,6 +63,8 @@ async function updateCard(topography = null) {
     if (["pe", "st"].includes(topography.task_state)) {
         try {
             const response = await axios.get(_topography.value.url);
+            _topography.value = response.data;
+            _disabled.value = _topography.value === null || _topography.value.permissions.current_user.permission === "view";
         } catch (error) {
             show?.({
                 props: {
@@ -75,7 +79,7 @@ async function updateCard(topography = null) {
 
 function deleteTopography() {
     axios.delete(_topography.value.url).then(response => {
-        this.$emit("topography-deleted", _topography.value.url);
+        emit("topography-deleted", _topography.value.url);
         const id = getIdFromUrl(_topography.value.surface);
         window.location.href = `/ui/dataset-detail/${id}/`;
     }).catch(error => {

--- a/frontend/base/NotificationOffcanvas.vue
+++ b/frontend/base/NotificationOffcanvas.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 
 import axios from "axios";
-import {onMounted, ref} from "vue";
+import {onBeforeUnmount, onMounted, ref} from "vue";
 
 import {
     BAlert,
@@ -28,9 +28,18 @@ const props = defineProps({
 
 const messages = ref([]);
 
+let pollingIntervalId = null;
+
 onMounted(() => {
-    setInterval(updateNotifications, props.pollingInterval);
+    pollingIntervalId = setInterval(updateNotifications, props.pollingInterval);
     updateNotifications();
+});
+
+onBeforeUnmount(() => {
+    if (pollingIntervalId != null) {
+        clearInterval(pollingIntervalId);
+        pollingIntervalId = null;
+    }
 });
 
 function updateNotifications() {
@@ -38,6 +47,10 @@ function updateNotifications() {
         .then(response => {
             unreadCount.value = response.data.unread_count;
             messages.value = response.data.unread_list;
+        })
+        .catch(error => {
+            // Swallow transient server errors so polling does not produce unhandled rejections
+            console.error("Failed to update notifications:", error);
         });
 }
 

--- a/frontend/components/BokehPlot.vue
+++ b/frontend/components/BokehPlot.vue
@@ -7,7 +7,7 @@
  */
 
 import {v4 as uuid4} from 'uuid';
-import {computed, onMounted, ref, watch} from "vue";
+import {computed, onBeforeUnmount, onMounted, ref, watch} from "vue";
 
 import {
     AjaxDataSource,
@@ -121,6 +121,7 @@ const _lineWidth = ref(1);
 
 // Reorganized plot information
 let _bokehFigures = [];  // Stores Bokeh figure, line and symbol objects
+let _bokehViews = [];  // Stores the views returned by `Plotting.show` so we can dispose them on unmount
 let _categoryElements = ref([]);  // Sorted categories with selectable elements
 let _categoryElementSelections = [];  // Flags which categories are selected
 
@@ -421,16 +422,22 @@ function createFigures() {
     for (const [index, figure] of _bokehFigures.entries()) {
         figure.legend = new Legend({items: figure.legendItems, visible: false});
         figure.figure.add_layout(figure.legend);
-        Plotting.show(figure.figure, `#bokeh-figure-${props.uid}-${index}`);
+        /* `Plotting.show` returns a (promise of a) view that embeds the figure in the DOM. We keep a reference so
+           that we can dispose the embedded view when the component is unmounted. */
+        _bokehViews.push(Plotting.show(figure.figure, `#bokeh-figure-${props.uid}-${index}`));
     }
 }
 
 function createPlots() {
-    /* Destroy all lines */
+    /* Destroy all lines. We also reset `sources` and `legendItems`, otherwise they accumulate on every rebuild
+       (triggered by the `dataSources` watcher) which duplicates legend entries and makes `setPlotVisibility`
+       index stale items. */
     for (const figure of _bokehFigures) {
         figure.lines.length = 0;
         figure.symbols.length = 0;
         figure.figure.renderers.length = 0;
+        figure.sources.length = 0;
+        figure.legendItems.length = 0;
     }
 
     /* Get first and second category (to decide on color and dash) */
@@ -659,6 +666,39 @@ function onTap(obj, data) {
     /* Emit event */
     emit("selected", obj, data);
 }
+
+onBeforeUnmount(() => {
+    /* Dispose the embedded Bokeh views so they do not leak once the component is gone. */
+    for (const viewOrPromise of _bokehViews) {
+        Promise.resolve(viewOrPromise).then(view => {
+            try {
+                if (view != null && typeof view.remove === "function") {
+                    view.remove();
+                }
+            } catch (e) {
+                /* Ignore errors during teardown */
+            }
+        }).catch(() => { /* Ignore rejected view promises during teardown */ });
+    }
+    _bokehViews.length = 0;
+
+    /* Clear the Bokeh documents and all accumulators. */
+    for (const figure of _bokehFigures) {
+        try {
+            const doc = figure.figure == null ? null : figure.figure.document;
+            if (doc != null && typeof doc.clear === "function") {
+                doc.clear();
+            }
+        } catch (e) {
+            /* Ignore errors during teardown */
+        }
+        figure.lines.length = 0;
+        figure.symbols.length = 0;
+        figure.sources.length = 0;
+        figure.legendItems.length = 0;
+    }
+    _bokehFigures.length = 0;
+});
 
 </script>
 

--- a/frontend/components/DeepZoomImage.vue
+++ b/frontend/components/DeepZoomImage.vue
@@ -6,7 +6,7 @@
  */
 
 import axios from "axios";
-import {onMounted, ref, watch} from "vue";
+import {onBeforeUnmount, onMounted, ref, watch} from "vue";
 import {BSpinner, useToastController} from "bootstrap-vue-next";
 
 const props = defineProps({
@@ -39,6 +39,10 @@ let viewer = null;
 // File list
 let inventory = null;
 
+// Bookkeeping for the 404-retry timeout and unmount state
+let retryTimeoutId = null;
+let isMounted = false;
+
 // GUI logic
 const _openSeadragonElement = ref(null);
 const _isLoaded = ref(false);
@@ -48,7 +52,26 @@ const _colormap = ref(null);
 const _errorMessage = ref(null);
 
 onMounted(() => {
+    isMounted = true;
     requestDzi();
+});
+
+onBeforeUnmount(() => {
+    isMounted = false;
+    // Stop any pending 404-retry
+    if (retryTimeoutId != null) {
+        clearTimeout(retryTimeoutId);
+        retryTimeoutId = null;
+    }
+    // Destroy the OpenSeadragon viewer
+    if (viewer != null) {
+        try {
+            viewer.destroy();
+        } catch (e) {
+            /* Ignore errors during teardown */
+        }
+        viewer = null;
+    }
 });
 
 
@@ -79,6 +102,12 @@ function getTileSource(meta) {
 
 
 function refreshDzi() {
+    // The viewer may not exist yet if the folderUrl/prefix watcher fires before `requestDzi` created it.
+    // In that case there is nothing to refresh; the initial `requestDzi` will pick up the new props.
+    if (viewer == null) {
+        return;
+    }
+
     // We are loading a new image
     _isLoaded.value = false;
 
@@ -86,6 +115,16 @@ function refreshDzi() {
     axios.get(props.folderUrl).then(response => {
         inventory = response.data;
         axios.get(inventory[`${props.prefix}dzi.json`].file).then(response => {
+            // Guard again: the viewer may have been destroyed while the request was in flight
+            if (viewer == null) {
+                return;
+            }
+            // Remove any previously loaded images before adding the new one
+            if (viewer.world != null) {
+                while (viewer.world.getItemCount() > 0) {
+                    viewer.world.removeItem(viewer.world.getItemAt(0));
+                }
+            }
             viewer.addTiledImage({
                 tileSource: getTileSource(response.data),
                 success: () => {
@@ -106,6 +145,11 @@ function refreshDzi() {
 
 
 function requestDzi() {
+    // Do not (re)start requests once the component has been unmounted
+    if (!isMounted) {
+        return;
+    }
+
     _isLoaded.value = false;
 
     axios.get(props.folderUrl).then(response => {
@@ -206,9 +250,11 @@ function requestDzi() {
         if (error_has_response && (error.response.status == 0)) {
             _errorMessage.value = "Canceled loading of plot.";
         } else if (error_has_response && (error.response.status == 404)) {
-            /* 404 indicates the resource is not yet available, retry */
+            /* 404 indicates the resource is not yet available, retry (unless we have been unmounted) */
             console.log("Resource not yet available, retrying...")
-            setTimeout(requestDzi, props.retryDelay);
+            if (isMounted) {
+                retryTimeoutId = setTimeout(requestDzi, props.retryDelay);
+            }
         } else {
             /* Treat any other code as an actual error */
             _errorMessage.value = error.message;

--- a/frontend/components/LineScanPlot.vue
+++ b/frontend/components/LineScanPlot.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 
 import axios from "axios";
-import {onMounted, ref} from "vue";
+import {onBeforeUnmount, onMounted, ref} from "vue";
 import {ColumnDataSource, Plotting} from "@bokeh/bokehjs";
 import {NetCDFReader} from 'netcdfjs';
 
@@ -12,6 +12,10 @@ const props = defineProps({
 });
 
 const _bokehPlotElement = ref(null);
+
+// Bokeh objects, kept so they can be disposed on unmount
+let _figure = null;
+let _view = null;
 
 onMounted(() => {
     axios.get(props.topography.squeezed_datafile?.file, {responseType: 'arraybuffer'})
@@ -46,8 +50,34 @@ onMounted(() => {
             });
 
             // Render to component
-            Plotting.show(figure, _bokehPlotElement.value);
+            _figure = figure;
+            _view = Plotting.show(figure, _bokehPlotElement.value);
         });
+});
+
+onBeforeUnmount(() => {
+    /* Dispose the embedded Bokeh view and clear the figure's document so they do not leak. */
+    if (_view != null) {
+        Promise.resolve(_view).then(view => {
+            try {
+                if (view != null && typeof view.remove === "function") {
+                    view.remove();
+                }
+            } catch (e) {
+                /* Ignore errors during teardown */
+            }
+        }).catch(() => { /* Ignore rejected view promises during teardown */ });
+        _view = null;
+    }
+    try {
+        const doc = _figure == null ? null : _figure.document;
+        if (doc != null && typeof doc.clear === "function") {
+            doc.clear();
+        }
+    } catch (e) {
+        /* Ignore errors during teardown */
+    }
+    _figure = null;
 });
 
 </script>

--- a/frontend/manager/BandwidthPlot.vue
+++ b/frontend/manager/BandwidthPlot.vue
@@ -1,6 +1,6 @@
 <script setup>
 
-import {onMounted, ref, watch} from "vue";
+import {onBeforeUnmount, onMounted, ref, watch} from "vue";
 import {ColumnDataSource, HoverTool, OpenURL, Plotting, TapTool} from "@bokeh/bokehjs";
 import {applyDefaultBokehStyle} from "../utils/bokeh";
 
@@ -12,6 +12,10 @@ const props = defineProps({
 });
 
 const _bokehPlotElement = ref(null);
+
+// Bokeh objects, kept so they can be disposed on unmount
+let _figure = null;
+let _view = null;
 
 // Hover tool
 const hover_tool = new HoverTool({
@@ -117,7 +121,8 @@ onMounted(() => {
     });
 
     // Render to component
-    Plotting.show(figure, _bokehPlotElement.value);
+    _figure = figure;
+    _view = Plotting.show(figure, _bokehPlotElement.value);
 
     // Set data
     setPlotData(props.topographies);
@@ -125,6 +130,35 @@ onMounted(() => {
 
 watch(() => props.topographies, (newValue, oldValue) => {
     setPlotData(newValue);
+});
+
+onBeforeUnmount(() => {
+    /* Dispose the embedded Bokeh view and clear the figure's document so they do not leak. */
+    if (_view != null) {
+        Promise.resolve(_view).then(view => {
+            try {
+                if (view != null && typeof view.remove === "function") {
+                    view.remove();
+                }
+            } catch (e) {
+                /* Ignore errors during teardown */
+            }
+        }).catch(() => { /* Ignore rejected view promises during teardown */ });
+        _view = null;
+    }
+    try {
+        const doc = _figure == null ? null : _figure.document;
+        if (doc != null && typeof doc.clear === "function") {
+            doc.clear();
+        }
+    } catch (e) {
+        /* Ignore errors during teardown */
+    }
+    _figure = null;
+    // Clear the data source accumulators
+    bw_source.data = {
+        y: [], left: [], cutoff: [], right: [], name: [], thumbnail: [], link: []
+    };
 });
 
 </script>

--- a/frontend/manager/DatasetPermissions.vue
+++ b/frontend/manager/DatasetPermissions.vue
@@ -23,7 +23,7 @@ const props = defineProps({
 });
 
 const emit = defineEmits([
-    'updated:permissions'
+    'update:permissions'
 ]);
 
 const isEditing = ref(false);
@@ -45,7 +45,7 @@ function saveCard() {
                 variant: 'danger'
             }
         });
-        selfPermissions.value = this.savedPermissions;
+        selfPermissions.value = savedPermissions.value;
     }).finally(() => {
         isSaving.value = false;
     });

--- a/frontend/manager/TopographyCard.vue
+++ b/frontend/manager/TopographyCard.vue
@@ -90,6 +90,9 @@ function topographyDeleted(url) {
 
 const topographyModel = computed({
     get() {
+        // FIXME: side-effect (scheduleStateCheck) inside a computed getter. The getter runs on every dependency
+        // read/re-evaluation, so state-check polling is scheduled at unpredictable times. This should be refactored
+        // to a watcher, but that is a higher-risk change handled in a separate pass.
         scheduleStateCheck(props.topography);
         return props.topography;
     },

--- a/frontend/stores/datasetSelection.ts
+++ b/frontend/stores/datasetSelection.ts
@@ -28,9 +28,12 @@ export const useDatasetSelectionStore = defineStore('selection', {
             this.datasetIds = this.datasetIds.filter(
                 (id: number): boolean => id !== datasetId
             );
+            // Also prune the cache so it does not grow unbounded
+            delete this.datasetCache[datasetId];
         },
         clear() {
             this.datasetIds = [];
+            this.datasetCache = {};
         },
         getDataset(datasetId: number) {
             return this.datasetCache[datasetId];


### PR DESCRIPTION
## Summary

Backend hardening and frontend bug fixes from a codebase audit. Backend and frontend changes are grouped here because they live in the same repository.

### Backend (`ce_ui/`)
- Require `DJANGO_SECRET_KEY` and `DJANGO_ADMIN_URL` in production (no weak per-process `random_string()` fallback); force `DEBUG=False`.
- `INSTALLED_APPS` built with order-preserving dedup (`dict.fromkeys`) instead of `set()`, which randomized app order across processes/restarts.
- Guard the base64 `subjects` query param so a missing/malformed value no longer 500s the analysis views.
- `import_terms`: `datetime.datetime.strptime` (module-vs-class typo that always crashed).
- `UserDetailView` denies non-collaborators (self, or sharing a viewable surface) instead of the no-op FIXME dispatch; the skipped regression test is re-enabled.
- Remove settings-time `print()` (corrupted management-command stdout); `ACCOUNT_`-prefix the allauth username settings; give `asgi.py` a settings-module default; parse `DJANGO_DEBUG` as a boolean in `wsgi.py`.

### Frontend (`frontend/`)
- Dispose Bokeh figures/views and OpenSeadragon viewers on unmount; stop the DeepZoom 404-retry loop after unmount; clear the notification poll interval; reset stale `sources`/`legendItems` on Bokeh rebuild.
- Replace `this.$emit` / `this.savedPermissions` (undefined in `<script setup>`) with `defineEmits` / refs — a successful topography delete now reports success and redirects, and permission rollback works.
- Assign the pending-topography refresh response instead of discarding it.
- **Escape** user-controlled `topography_name` / `topography_url` in the roughness DataTables cell (stored XSS); guard the null `_analyses` map.
- Parenthesize the dataset Delete-button `v-if` so it respects full access while versions load.
- Dataset-list search: stale-response guard + `encodeURIComponent`; prune `datasetCache` on unselect/clear.

`TasksButton` / `TopographyCard` side-effect-in-computed cases are marked `FIXME` for a later refactor. **No API URLs were changed** — the v1→v2 migration is a separate track.

## Testing

`devbox run test-ui`: 25 passed, 2 pre-existing skips. Frontend webpack build compiles cleanly (no test runner is configured in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
