### PR TITLE
MAINT: Drop organization URL wiring and stale test kwarg

### DIFF
--- a/ce_ui/tests/conftest.py
+++ b/ce_ui/tests/conftest.py
@@ -13,7 +13,7 @@ from .fixtures import orcid_socialapp  # noqa: F401
 def user_with_plugin(db):
     """Fixture returning a user with ce_ui plugin access."""
     org_name = "Test Organization"
-    org = OrganizationFactory(name=org_name, plugins_available="ce_ui")
+    org = OrganizationFactory(name=org_name)
     user = UserFactory()
     user.groups.add(org.group)
     return user

--- a/ce_ui/urls.py
+++ b/ce_ui/urls.py
@@ -72,10 +72,6 @@ urlpatterns = [
                     include("topobank_rest_api.users.urls", namespace="users"),
                 ),
                 path(
-                    "organizations/",
-                    include("topobank_rest_api.organizations.urls", namespace="organizations"),
-                ),
-                path(
                     "authorization/",
                     include("topobank_rest_api.authorization.urls", namespace="authorization"),
                 ),


### PR DESCRIPTION
Companion to the topobank-rest-api / topobank-orcid organization-management removal. Removes the dead `organizations/` REST URL include and stops passing the removed `plugins_available` kwarg to OrganizationFactory in a test fixture. The Organization model, the `all` group, ensure_default_group and TOPOBANK_ORGANIZATION_MODEL are kept — topobank core still owns datasets by organization.

Testing: `devbox run test-ui` 25 passed, 2 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)