### PR TITLE
ENH: Show topobank-rest-api and topobank-orcid versions in the user s…

### DIFF
--- a/ce_ui/settings/base.py
+++ b/ce_ui/settings/base.py
@@ -477,6 +477,18 @@ TRACKED_DEPENDENCIES = [
         "https://github.com/ContactEngineering/topobank",
     ),
     (
+        "topobank_rest_api",
+        "topobank_rest_api.__version__",
+        "MIT",
+        "https://github.com/ContactEngineering/topobank-rest-api",
+    ),
+    (
+        "topobank_orcid",
+        "topobank_orcid.__version__",
+        "MIT",
+        "https://github.com/ContactEngineering/topobank-orcid",
+    ),
+    (
         "topobank_statistics",
         "topobank_statistics.__version__",
         "MIT",

--- a/frontend/components/layout/VersionInformation.vue
+++ b/frontend/components/layout/VersionInformation.vue
@@ -27,6 +27,12 @@ onMounted(() => {
         <a v-if="versions.topobank" :href="versions.topobank.homepage">
             topobank
         </a><span v-if="versions.topobank"> v{{ versions.topobank.version }},</span>
+        <a v-if="versions.topobank_rest_api" :href="versions.topobank_rest_api.homepage">
+            rest-api
+        </a><span v-if="versions.topobank_rest_api"> v{{ versions.topobank_rest_api.version }},</span>
+        <a v-if="versions.topobank_orcid" :href="versions.topobank_orcid.homepage">
+            orcid
+        </a><span v-if="versions.topobank_orcid"> v{{ versions.topobank_orcid.version }},</span>
         <a v-if="versions.ce_ui" :href="versions.ce_ui.homepage">
             ui
         </a><span v-if="versions.ce_ui"> v{{ versions.ce_ui.version }}</span>;


### PR DESCRIPTION
…ide panel

Both packages are hard dependencies of ce-ui (`topobank_rest_api` is imported by the URL configuration, `topobank_orcid` provides the user and authorization apps), so they are tracked unconditionally and displayed as "rest-api" and "orcid" next to the topobank version.