### PR TITLE
BUILD: Force-include the app's static files in the distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,11 @@ splinter_tests.*/
 
 # Django stuff:
 staticfiles/
-static/
+# Anchored to the repository root: this is the webpack output directory. An
+# unanchored `static/` would also match `ce_ui/static/`, which holds tracked
+# application assets, and hatchling would then exclude them from the built
+# distributions (see `artifacts` in pyproject.toml).
+/static/
 
 # Sphinx documentation
 docs/_build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,45 @@
 
 ## 1.33.0 (2026-08-02)
 
-- MAINT: The changelog is no longer served as a static file. The component
-  versions in the side panel link to the respective repositories, where the
-  changelogs are published, which covers all components rather than just this one
-- BUILD: Force-include the app's static files in the built distribution. The bare
-  `static/` pattern in `.gitignore` also matched `ce_ui/static/`, and since
-  hatchling honours VCS ignore files the favicon, logos, Creative Commons images,
-  terms & conditions and the vendored OpenSeadragon viewer were missing from the
-  wheel, so `collectstatic` could not collect them
-- BUILD: Anchored the `static/` pattern in `.gitignore` to the repository root, so
-  it only matches the webpack output directory
+- ENH: Visual facelift: new analysis and dataset card style, tabs instead of pills,
+  homogenized toolbars, less chrome
+- ENH: Contextual help throughout the site
+- ENH: User and tasks dashboard
+- ENH: Token-based search
+- ENH: Asynchronous ZIP downloads
+- ENH: Citation recommendation for published datasets
+- ENH: Reintroduced the supported file formats overview page
+- ENH: Component versions shown in the user side panel, including
+  `topobank-rest-api` and `topobank-orcid`
+- ENH: Spinner while the site is loading
+- BUG: Hardened settings and fixed backend and frontend audit findings
+- BUG: Forward the CSRF token from the cookie on axios requests; fixed the
+  topography delete URL
+- BUG: Fixed the user search modal (wrong endpoint, paginated response)
+- BUG: No spinner is shown when all tasks have failed
+- BUG: Fixed error reporting and the version information in the offcanvas
+- MAINT: The Django project configuration lives here now: `manage.py`, the
+  `ce_ui.settings.*` modules, the root URL configuration and the WSGI/ASGI entry
+  points moved over from `topobank`
+- MAINT: Plugins are wired explicitly through `INSTALLED_APPS`; removed the old
+  entry-point plugin system and plugin permissions
+- MAINT: REST API split into `topobank-rest-api`; users, organizations and
+  authorization into `topobank-orcid`; removed django-guardian
+- MAINT: Reorganized the JS component structure; logic extracted into tested TS
+  modules
+- MAINT: Celery beat task for truncating the request profiler log
+- MAINT: Refresh of Bokeh plots for visualization
+- MAINT: Physical sizes are displayed without e-notation
+- MAINT: `analysis_function` -> `workflow`
+- MAINT: The changelog is no longer served as a static file; the component versions
+  in the side panel link to the repositories where changelogs are published
+- BUILD: Changed build system to hatchling
+- BUILD: Load BokehJS from a prebuilt bundle instead of re-bundling it (#67)
+- BUILD: Updated frontend dependencies (Bokeh 3.9, Pinia 4, OpenSeadragon 6,
+  DataTables 3, bootstrap-vue-next 0.45)
+- BUILD: Force-include the app's static files in the distribution; they were missing
+  from the wheel because `.gitignore` matched `ce_ui/static/`
+- BUILD: Anchored the `static/` pattern in `.gitignore` to the repository root
 
 ## 1.32.0 (2025-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog for plugin *ce-ui*
 
+## 1.33.0 (2026-08-02)
+
+- MAINT: The changelog is no longer served as a static file. The component
+  versions in the side panel link to the respective repositories, where the
+  changelogs are published, which covers all components rather than just this one
+- BUILD: Force-include the app's static files in the built distribution. The bare
+  `static/` pattern in `.gitignore` also matched `ce_ui/static/`, and since
+  hatchling honours VCS ignore files the favicon, logos, Creative Commons images,
+  terms & conditions and the vendored OpenSeadragon viewer were missing from the
+  wheel, so `collectstatic` could not collect them
+- BUILD: Anchored the `static/` pattern in `.gitignore` to the repository root, so
+  it only matches the webpack output directory
+
 ## 1.32.0 (2025-12-16)
 
 - ENH: Dataset Collection view and publish UI

--- a/ce_ui/static/other/CHANGELOG.md
+++ b/ce_ui/static/other/CHANGELOG.md
@@ -1,1 +1,0 @@
-../../../CHANGELOG.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,18 @@ repository = 'https://github.com/ContactEngineering/ce-ui'
 
 [tool.hatch.version]
 source = "vcs"
+
+[tool.hatch.build]
+# `.gitignore` contains a bare `static/` pattern, meant for the webpack output
+# directory at the repository root and for `staticfiles/`. It also matches this
+# package's own static directory, and hatchling honours VCS ignore files when
+# selecting files for a distribution. Without this override the app's static
+# assets (favicon, logos, Creative Commons images, terms & conditions, the
+# vendored OpenSeadragon viewer) are absent from the built wheel, so Django's
+# `AppDirectoriesFinder` cannot find them and `collectstatic` silently omits
+# them. `ManifestStaticFilesStorage` then raises `ValueError: Missing staticfiles
+# manifest entry for ...` on the first `{% static %}` lookup.
+artifacts = ["ce_ui/static/**"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["ce_ui"]


### PR DESCRIPTION
## Problem

`.gitignore` contains a bare `static/` pattern, meant for the webpack output directory at the repository root and for `staticfiles/`. It also matches `ce_ui/static/`, and hatchling honours VCS ignore files when selecting files for a distribution — so the wheel shipped `ce_ui/templates/` (30 entries) but **zero** `ce_ui/static/` entries. That is 25 files: the favicon, `ce_logo.svg`, the ORCID icon, Creative Commons images, funder logos, the two screenshots, `thumbnail_unavailable.png`, the terms & conditions markdown and the vendored OpenSeadragon viewer.

Django's `AppDirectoriesFinder` could then not find them, `collectstatic` silently omitted them, and `ManifestStaticFilesStorage` raised

```
ValueError: Missing staticfiles manifest entry for 'images/favicons/favicon.png'
```

while rendering `base.html` — i.e. on every page. This is what took production down.

It does not show up in development, where the package is installed in editable mode and the finder reads the source tree directly. Only a wheel-based build is affected.

## Fix

- Force-include the assets via `artifacts` in `pyproject.toml`, plus an explicit `packages` declaration
- Anchor the ignore pattern to `/static/` so it only matches the webpack output directory at the repository root

## Also: the changelog is no longer shipped to users

Removed `ce_ui/static/other/CHANGELOG.md`, a tracked symlink to the top-level `CHANGELOG.md`. Beyond duplicating a source document into the static tree, a tracked symlink is fragile: on a checkout with `core.symlinks=false` git materialises it as a regular file containing the literal text `../../../CHANGELOG.md`, which would then be built and served as "the changelog" — silently wrong rather than broken.

Its only consumer was the `--changelog` option of `notify_users`, removed in ContactEngineering/topobank-orcid. Users reach changelogs through the component versions in the side panel (`VersionInformation.vue`), which link to each repository — the more useful destination now that there are seven of them.

## Also: the changelog was 134 commits out of date — **please review**

`1.32.0` is tagged, but the changelog had not been touched since, although 134 non-merge commits had landed. The other repositories got their release entries in `prep_release_2026-07-31`; this one was missed.

I reconstructed a `1.33.0` entry from `git log 1.32.0..HEAD`, one line per change, covering the split of the REST API and user handling into separate packages, the move of the Django configuration into this repository, the visual facelift, the user and tasks dashboard, token-based search, asynchronous ZIP downloads and the frontend dependency updates.

**These entries were written from commit messages, not by the authors of the changes**, so please check for anything mischaracterized or missing — and confirm the version number. `1.33.0` matches the minor bumps of the sibling repositories in the same release train, but a release carrying the split may warrant something larger.

## Testing

Verified by building the wheel (all 24 tracked `ce_ui/static` files present, untracked `.DS_Store` correctly excluded) and in a full stack image build:

- `collectstatic`: 281 files copied, 767 post-processed
- 7 spot-checked assets resolve via `{% static %}` to hashed URLs; `base.html` renders
- `other/CHANGELOG.md` now correctly raises `ValueError`, and 0 `CHANGELOG*` entries remain in `staticfiles.json`
- Ignore-pattern behaviour checked: webpack output still ignored, app assets now visible to git, `.DS_Store` still ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)