### PR TITLE
BUG: Show the username when a user has no name; MAINT: explicit Celery time limits and analysis memory settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - BUG: Task dashboard shows the username when a user has no name set
+- MAINT: Celery task time limits are now explicit and env-configurable
+- MAINT: Added `TOPOBANK_ANALYSIS_MEMORY_*` settings for the analysis memory guard
 
 ## 1.33.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for plugin *ce-ui*
 
+## Unreleased
+
+- BUG: Task dashboard shows the username when a user has no name set
+
 ## 1.33.0 (2026-08-02)
 
 - ENH: Visual facelift: new analysis and dataset card style, tabs instead of pills,

--- a/ce_ui/settings/base.py
+++ b/ce_ui/settings/base.py
@@ -322,11 +322,17 @@ CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_serializer
 CELERY_RESULT_SERIALIZER = "json"
-# TODO: set to whatever value is adequate in your circumstances
-# CELERYD_TASK_TIME_LIMIT = 5 * 60
-# http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-soft-time-limit
-# TODO: set to whatever value is adequate in your circumstances
-# CELERYD_TASK_SOFT_TIME_LIMIT = 60
+# Time limits. `topobank.analysis.tasks` applies these to its tasks explicitly
+# (falling back to the same defaults when the settings are absent), so a task
+# that runs away is killed rather than occupying a slot forever. The soft limit
+# raises `SoftTimeLimitExceeded` inside the task, which its own error handling
+# turns into a recorded FAILURE with partial timings; the hard limit is the
+# backstop that kills the child process if that does not work.
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-time-limit
+CELERY_TASK_TIME_LIMIT = env.int("CELERY_TASK_TIME_LIMIT", default=6 * 3600)
+CELERY_TASK_SOFT_TIME_LIMIT = env.int(
+    "CELERY_TASK_SOFT_TIME_LIMIT", default=CELERY_TASK_TIME_LIMIT - 300
+)
 # https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-acks-late
 CELERY_TASK_ACKS_LATE = False
 # https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-publish-retry
@@ -728,6 +734,27 @@ DELETE_EXISTING_FILES = env.bool("TOPOBANK_DELETE_EXISTING_FILES", default=False
 # ------------------------------------------------------------------------------
 TOPOBANK_THUMBNAIL_FORMAT = "jpeg"  # File format for thumbnails
 TOPOBANK_DELETE_DELAY = timedelta(days=7)  # Hold deleted datasets this long
+
+# Memory budget for a single analysis, in bytes. An analysis predicted to need
+# more than this is failed before it starts, with an explanatory message, rather
+# than being killed by the OOM killer half way through - see
+# `topobank.analysis.sizing`, which learns the per-workflow memory coefficient
+# from the peak usage recorded by previous runs. Set to 0 to disable the guard,
+# which is the default: without a value tuned to the workers actually deployed,
+# refusing work is worse than the status quo.
+TOPOBANK_ANALYSIS_MEMORY_BUDGET = env.int("TOPOBANK_ANALYSIS_MEMORY_BUDGET", default=0)
+# Percentile of observed bytes-per-point used for the prediction, the factor
+# applied on top of it, and how many observations a workflow needs before its
+# coefficient is trusted at all. The defaults live in `analysis.sizing`.
+TOPOBANK_ANALYSIS_MEMORY_PERCENTILE = env.float(
+    "TOPOBANK_ANALYSIS_MEMORY_PERCENTILE", default=0.95
+)
+TOPOBANK_ANALYSIS_MEMORY_SAFETY_FACTOR = env.float(
+    "TOPOBANK_ANALYSIS_MEMORY_SAFETY_FACTOR", default=1.2
+)
+TOPOBANK_ANALYSIS_MEMORY_MIN_SAMPLES = env.int(
+    "TOPOBANK_ANALYSIS_MEMORY_MIN_SAMPLES", default=5
+)
 
 
 # ALLAUTH SETTINGS

--- a/frontend/pages/StaffTaskDashboard.vue
+++ b/frontend/pages/StaffTaskDashboard.vue
@@ -131,6 +131,21 @@ function resetOrdering() {
     load();
 }
 
+/**
+ * Label for the user who created a task.
+ *
+ * `name` is not guaranteed to be a usable label: it can be empty, or
+ * whitespace-only for accounts with neither a name nor a first/last name (the
+ * anonymous user, for instance). Those must fall back to the username rather
+ * than render an empty cell, which reads as "this task has no user".
+ */
+function userLabel(user: any): string {
+    if (user == null) {
+        return "–";
+    }
+    return user.name?.trim() || user.username?.trim() || "–";
+}
+
 /** Link to the UI page for a task's subject, if it has one we can link to. */
 function subjectHref(subject: any): string | null {
     if (subject == null || subject.id == null) {
@@ -257,7 +272,7 @@ function subjectHref(subject: any): string | null {
                         </div>
                     </td>
                     <td class="small">
-                        {{ task.created_by?.name ?? "–" }}
+                        {{ userLabel(task.created_by) }}
                     </td>
                     <td class="small">{{ task.queue ?? "–" }}</td>
                     <td class="small">


### PR DESCRIPTION
Two independent changes, both surfaced while debugging a production instance.
They are in one PR because the branch was already open; say the word and I will
split the settings commit out.

## 1. Blank user in the task dashboard (`BUG`)

The user cell of the staff task dashboard was

```vue
{{ task.created_by?.name ?? "–" }}
```

Nullish coalescing only catches `null` and `undefined`, never `""` or `" "`.
Accounts without a name end up with exactly such a value (see
ContactEngineering/topobank-orcid#7), so the cell rendered blank and read as
"this task has no user" — most visibly on failed rows, where the eye goes looking
for who ran the task.

Replaced with a `userLabel` helper: name, else username, else an en dash for a
genuinely absent user (`created_by` is nullable, and `on_delete=SET_NULL` means a
purged account really does leave rows without one).

Worth noting the symptom was first reported on tasks killed by the OOM killer
(`Worker exited prematurely: signal 9 (SIGKILL)`), but the kill is incidental —
the Celery failure handler never touches `created_by`. Those rows simply belonged
to a user with no usable display name.

## 2. Celery time limits and analysis memory settings (`MAINT`)

`CELERYD_TASK_TIME_LIMIT` and `CELERYD_TASK_SOFT_TIME_LIMIT` sat commented out
with a "set to whatever value is adequate" TODO, which reads as if no limits
apply. They do — `topobank.analysis.tasks` reads `CELERY_TASK_TIME_LIMIT` /
`CELERY_TASK_SOFT_TIME_LIMIT` and falls back to a six-hour hard limit — so the
stale comments are now the real settings, env-configurable, with the same
defaults.

Also adds the `TOPOBANK_ANALYSIS_MEMORY_*` settings consumed by the memory guard
in ContactEngineering/topobank#1377. The budget defaults to `0`, which disables
the guard: without a value tuned to the workers actually deployed, refusing work
is worse than the status quo.

## Companion PRs

- ContactEngineering/topobank-orcid#7 — root cause of the blank name
- ContactEngineering/topobank-rest-api#9 — serializer-side fallback
- ContactEngineering/topobank#1377 — the memory guard these settings configure

## Verification

`userLabel` was exercised in node against `null`, `undefined`, `""`, `" "`, a
missing key, a whitespace-only username, and a name needing trimming — all nine
cases behave as intended.

**Not run:** this checkout has no `node_modules`, so neither the webpack build nor
`vitest` was executed, and the settings change was not loaded by a real Django
process. Both want a pass in ce-devbox before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)