### PR TITLE
MAINT: Add TOPOBANK_ANALYSIS_MEMORY_WINDOW_DAYS

### DIFF
--- a/ce_ui/settings/base.py
+++ b/ce_ui/settings/base.py
@@ -755,6 +755,13 @@ TOPOBANK_ANALYSIS_MEMORY_SAFETY_FACTOR = env.float(
 TOPOBANK_ANALYSIS_MEMORY_MIN_SAMPLES = env.int(
     "TOPOBANK_ANALYSIS_MEMORY_MIN_SAMPLES", default=5
 )
+# How far back the coefficients are learned from. This window is what lets a
+# coefficient fall again after a workflow is optimised: over an unbounded history
+# a high percentile barely moves, so the guard would keep predicting
+# pre-optimisation memory and start refusing analyses that now fit.
+TOPOBANK_ANALYSIS_MEMORY_WINDOW_DAYS = env.int(
+    "TOPOBANK_ANALYSIS_MEMORY_WINDOW_DAYS", default=90
+)
 
 
 # ALLAUTH SETTINGS


### PR DESCRIPTION
Follow-up to #290, which added the `TOPOBANK_ANALYSIS_MEMORY_*` settings. This
adds the one that was missing.

The analysis memory guard in ContactEngineering/topobank#1377 learns a
bytes-per-grid-point coefficient per workflow from the `task_memory` that
completed runs record. As first written it learned over the *entire* history,
which means the coefficient can only ever ratchet upwards: with N old runs at the
old cost, an optimisation that halves memory usage moves a 95th percentile only
once the improved runs outnumber the old ones nineteen to one. Against the ~41k
rows on the production instance that is ~790k new runs — in practice never. The
guard would keep predicting pre-optimisation memory and start refusing analyses
that now fit comfortably, which is the failure direction that actually costs a
user something.

`TOPOBANK_ANALYSIS_MEMORY_WINDOW_DAYS` (90 by default) bounds how far back the
coefficients are learned from, so old runs age out and the coefficient follows the
code. A workflow with no runs inside the window has no coefficient at all and the
guard abstains, which is the same fail-open direction as the rest of that module.

Paired with ContactEngineering/topobank#1377, which contains the windowing itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)