### PR TITLE
ENH: Real-space size scale as a second axis on PSD plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   `0:00:42.123456` of the API, at a resolution that means something
 - ENH: Reloading a dataset, measurement or contact-mechanics page returns to the tab
   that was open instead of the first one
+- ENH: Power-spectral density plots carry a second axis above them showing the
+  real-space size scale λ = 2π/q
 - BUG: Task dashboard shows the username when a user has no name set
 - MAINT: Removed the npm dependencies that nothing imports, left over from when
   webpack still bundled BokehJS from source

--- a/frontend/components/ui/BokehPlot.vue
+++ b/frontend/components/ui/BokehPlot.vue
@@ -13,8 +13,10 @@ import {
     HoverTool,
     Legend,
     LegendItem,
+    LogAxis,
     Palettes,
     Plotting,
+    Range1d,
     SaveTool,
     Scatter,
     TapTool
@@ -26,6 +28,7 @@ import {
     BTabs
 } from "bootstrap-vue-next";
 
+import {wavelengthAxis, wavelengthRange} from "@/utils/axes";
 import {applyDefaultBokehStyle} from "@/utils/bokeh";
 import {slugifyFilename} from "@/utils/download";
 import {
@@ -109,6 +112,11 @@ let _categoryElementSelections = [];  // Flags which categories are selected
 // Colors
 const _parentColorPalette = Palettes.Greys256;  // Surfaces are shown in black/grey
 const _childColorPalette = Palettes.Plasma256;  // Plasma is used for topographies
+
+/* Name under which the range of the secondary real-space axis is registered on a
+   figure. Bokeh addresses an extra range by name, and there is at most one of
+   these per figure. */
+const WAVELENGTH_RANGE = "wavelength";
 
 onMounted(() => {
     isMounted.value = true;
@@ -286,6 +294,43 @@ function destroyBokehViews() {
     _bokehFigures.length = 0;
 }
 
+/* Add a second x axis above the plot showing the wavelength that corresponds to
+   the wavevector below it.
+
+   Bokeh links a secondary axis by giving it its own range, so the two are kept
+   in step by recomputing that range whenever the primary one changes: on the
+   initial auto-range, on zoom and pan, and on reset. The mapping itself is left
+   to the axis, which is why this is only offered for logarithmic axes, where
+   `log λ = log 2π − log q` is affine in the coordinates the axis is drawn in
+   (see `wavelengthAxis`).
+
+   The axis is added before the default style is applied, so that it picks up the
+   same fonts and tick formatting as every other axis on the site. */
+function addWavelengthAxis(figure, wavelength) {
+    // A decade wide and positive, rather than the default range starting at
+    // zero, which a logarithmic scale cannot map. It is replaced with the real
+    // bounds as soon as the primary range knows them.
+    const range = new Range1d({start: 1, end: 10});
+    figure.extra_x_ranges = {...figure.extra_x_ranges, [WAVELENGTH_RANGE]: range};
+    figure.add_layout(new LogAxis({
+        x_range_name: WAVELENGTH_RANGE,
+        axis_label: wavelength.label
+    }), "above");
+
+    const synchronize = () => {
+        const bounds = wavelengthRange(figure.x_range.start, figure.x_range.end);
+        if (bounds != null) {
+            range.setv(bounds);
+        }
+    };
+    // The primary range is a `DataRange1d`, so its bounds are unset until the
+    // view has computed them from the data; the change signals cover that first
+    // assignment as well as later interaction.
+    figure.x_range.properties.start.change.connect(synchronize);
+    figure.x_range.properties.end.change.connect(synchronize);
+    synchronize();
+}
+
 function createFigures() {
     destroyBokehViews();
 
@@ -330,6 +375,14 @@ function createFigures() {
             tools: tools,
             output_backend: props.outputBackend
         });
+
+        /* A wavevector axis gets a second axis above it showing the size scale
+           2π/q, which is what a reader without a background in spectral analysis
+           can interpret. */
+        const wavelength = wavelengthAxis(plot.xAxisLabel, xAxisType);
+        if (wavelength != null) {
+            addWavelengthAxis(figure, wavelength);
+        }
 
         applyDefaultBokehStyle(figure);
 

--- a/frontend/utils/axes.test.ts
+++ b/frontend/utils/axes.test.ts
@@ -1,0 +1,102 @@
+import {describe, expect, it} from "vitest";
+
+import {
+    parseAxisLabel,
+    reciprocalLengthUnit,
+    wavelengthAxis,
+    wavelengthRange
+} from "@/utils/axes";
+
+describe("parseAxisLabel", () => {
+    it("splits the unit off the quantity", () => {
+        expect(parseAxisLabel("Wavevector (µm⁻¹)")).toEqual({quantity: "Wavevector", unit: "µm⁻¹"});
+    });
+
+    it("handles a label without a unit", () => {
+        expect(parseAxisLabel("Slope")).toEqual({quantity: "Slope", unit: null});
+    });
+
+    it("handles an empty unit, which the backend writes for a dimensionless axis", () => {
+        expect(parseAxisLabel("Slope ()")).toEqual({quantity: "Slope", unit: ""});
+    });
+
+    it("takes the trailing parenthesis, not an earlier one", () => {
+        expect(parseAxisLabel("PSD (1D) (µm³)")).toEqual({quantity: "PSD (1D)", unit: "µm³"});
+    });
+
+    it("handles missing input", () => {
+        expect(parseAxisLabel(null)).toEqual({quantity: "", unit: null});
+        expect(parseAxisLabel(undefined)).toEqual({quantity: "", unit: null});
+    });
+});
+
+describe("reciprocalLengthUnit", () => {
+    it("recognizes the spelling the backend produces", () => {
+        expect(reciprocalLengthUnit("µm⁻¹")).toBe("µm");
+        expect(reciprocalLengthUnit("nm⁻¹")).toBe("nm");
+        expect(reciprocalLengthUnit("m⁻¹")).toBe("m");
+    });
+
+    it("recognizes hand-written spellings", () => {
+        expect(reciprocalLengthUnit("1/µm")).toBe("µm");
+        expect(reciprocalLengthUnit("1 / nm")).toBe("nm");
+        expect(reciprocalLengthUnit("mm^-1")).toBe("mm");
+    });
+
+    it("rejects units that are not a reciprocal length", () => {
+        expect(reciprocalLengthUnit("µm")).toBeNull();
+        expect(reciprocalLengthUnit("µm³")).toBeNull();
+        expect(reciprocalLengthUnit("1/s")).toBeNull();
+        expect(reciprocalLengthUnit("")).toBeNull();
+        expect(reciprocalLengthUnit(null)).toBeNull();
+    });
+});
+
+describe("wavelengthAxis", () => {
+    it("adds an axis to a logarithmic wavevector axis", () => {
+        expect(wavelengthAxis("Wavevector (µm⁻¹)", "log")).toEqual({
+            label: "Wavelength λ = 2π/q (µm)",
+            unit: "µm"
+        });
+    });
+
+    it("is case-insensitive about the quantity", () => {
+        expect(wavelengthAxis("wavevector (nm⁻¹)", "log")).not.toBeNull();
+    });
+
+    it("does not add one to the curvature distribution, which is also a reciprocal length", () => {
+        expect(wavelengthAxis("Curvature (µm⁻¹)", "log")).toBeNull();
+    });
+
+    it("does not add one to a linear axis, where the linked range would misplace ticks", () => {
+        expect(wavelengthAxis("Wavevector (µm⁻¹)", "linear")).toBeNull();
+        expect(wavelengthAxis("Wavevector (µm⁻¹)", null)).toBeNull();
+    });
+
+    it("does not add one when the unit is not a reciprocal length", () => {
+        expect(wavelengthAxis("Wavevector", "log")).toBeNull();
+        expect(wavelengthAxis("Wavevector (µm)", "log")).toBeNull();
+    });
+});
+
+describe("wavelengthRange", () => {
+    it("inverts the interval", () => {
+        const range = wavelengthRange(1, 10);
+        expect(range.start).toBeCloseTo(2 * Math.PI);
+        expect(range.end).toBeCloseTo(2 * Math.PI / 10);
+    });
+
+    it("returns a range that runs from large to small wavelengths", () => {
+        const range = wavelengthRange(0.1, 100);
+        expect(range.start).toBeGreaterThan(range.end);
+    });
+
+    it("has no result while the primary range is unknown or unusable", () => {
+        expect(wavelengthRange(null, 10)).toBeNull();
+        expect(wavelengthRange(1, null)).toBeNull();
+        expect(wavelengthRange(0, 10)).toBeNull();
+        expect(wavelengthRange(-1, 10)).toBeNull();
+        expect(wavelengthRange(1, Infinity)).toBeNull();
+        expect(wavelengthRange(NaN, 10)).toBeNull();
+    });
+});

--- a/frontend/utils/axes.ts
+++ b/frontend/utils/axes.ts
@@ -1,0 +1,142 @@
+/**
+ * Helpers for the secondary real-space axis on reciprocal-space plots.
+ *
+ * A power-spectral density is plotted against wavevector, which is the quantity
+ * the mathematics is written in but not the one a reader thinks in. Showing the
+ * corresponding wavelength λ = 2π/q on a second axis above the plot makes the
+ * size scale a feature appears at readable directly off the figure.
+ */
+
+import {LENGTH_UNIT_EXPONENTS} from "@/utils/units";
+
+/** The quantity whose axis gets a wavelength counterpart, lower-cased. */
+const WAVEVECTOR = "wavevector";
+
+/**
+ * A reciprocal length, in the spellings the backend produces (`µm⁻¹`, built
+ * from the measurement's unit) and the ones a hand-written label might use
+ * (`1/µm`, `µm^-1`).
+ */
+const RECIPROCAL_UNIT_PATTERNS = [
+    /^1\s*\/\s*(\S+)$/,
+    /^(\S+?)\s*⁻¹$/,
+    /^(\S+?)\s*\^-1$/,
+];
+
+export interface AxisLabel {
+    /** The quantity, e.g. "Wavevector". */
+    quantity: string;
+    /** The unit from the trailing parenthesis, or null if the label has none. */
+    unit: string | null;
+}
+
+/**
+ * Split an axis label into the quantity and its unit.
+ *
+ * The backend appends the unit in parentheses (`"Wavevector (µm⁻¹)"`), which is
+ * the only place the unit of an axis is available to us — the card
+ * configuration does not carry it separately.
+ *
+ * @param label The axis label.
+ * @returns The quantity and unit.
+ */
+export function parseAxisLabel(label: string | null | undefined): AxisLabel {
+    if (label == null) {
+        return {quantity: "", unit: null};
+    }
+    const match = /^(.*?)\s*\(([^()]*)\)\s*$/.exec(label);
+    if (match == null) {
+        return {quantity: label.trim(), unit: null};
+    }
+    return {quantity: match[1].trim(), unit: match[2].trim()};
+}
+
+/**
+ * The length unit a reciprocal-length unit is built from.
+ *
+ * @param unit The unit to inspect, e.g. "µm⁻¹".
+ * @returns The length unit ("µm"), or null if this is not a reciprocal length.
+ *     A reciprocal of something that is not a length — the curvature
+ *     distribution is also plotted against `µm⁻¹` — has no length unit and is
+ *     rejected here, but note that it is the quantity, not the unit, that makes
+ *     a wavelength axis meaningful; see `wavelengthAxis`.
+ */
+export function reciprocalLengthUnit(unit: string | null | undefined): string | null {
+    if (unit == null) {
+        return null;
+    }
+    for (const pattern of RECIPROCAL_UNIT_PATTERNS) {
+        const match = pattern.exec(unit.trim());
+        if (match != null && match[1] in LENGTH_UNIT_EXPONENTS) {
+            return match[1];
+        }
+    }
+    return null;
+}
+
+export interface WavelengthAxis {
+    /** Label for the secondary axis, including its unit. */
+    label: string;
+    /** Length unit of the secondary axis. */
+    unit: string;
+}
+
+/**
+ * Decide whether a plot gets a wavelength axis, and how it is labelled.
+ *
+ * Two conditions, both necessary:
+ *
+ * 1. The x axis carries a wavevector. A reciprocal length alone is not enough —
+ *    the curvature distribution is plotted against `µm⁻¹` as well, and 2π over
+ *    a curvature is not a size scale.
+ * 2. The x axis is logarithmic. The secondary axis is a Bokeh range linked to
+ *    the primary one, and such a link can only express a mapping that is affine
+ *    in the coordinates the axis is drawn in. `log λ = log 2π − log q` is affine
+ *    in log space, so a log axis is exact; on a linear axis the same link would
+ *    silently misplace every tick.
+ *
+ * @param label The label of the primary x axis.
+ * @param axisType The Bokeh axis type of the primary x axis.
+ * @returns The secondary axis to add, or null if this plot gets none.
+ */
+export function wavelengthAxis(label: string | null | undefined,
+                               axisType: string | null | undefined): WavelengthAxis | null {
+    if (axisType !== "log") {
+        return null;
+    }
+    const {quantity, unit} = parseAxisLabel(label);
+    if (quantity.toLowerCase() !== WAVEVECTOR) {
+        return null;
+    }
+    const lengthUnit = reciprocalLengthUnit(unit);
+    if (lengthUnit == null) {
+        return null;
+    }
+    // Naming the relation spells out for a reader who has not met a PSD before
+    // how the two axes belong together.
+    return {label: `Wavelength λ = 2π/q (${lengthUnit})`, unit: lengthUnit};
+}
+
+/**
+ * The wavelength interval corresponding to a wavevector interval.
+ *
+ * λ = 2π/q inverts the order of the interval, so the returned range runs from
+ * large to small wavelengths, matching the left-to-right direction of the
+ * wavevector axis below it.
+ *
+ * @param start Lower end of the wavevector range.
+ * @param end Upper end of the wavevector range.
+ * @returns Start and end of the wavelength range, or null while the primary
+ *     range is not yet known or does not admit a wavelength (a wavevector of
+ *     zero has no finite wavelength).
+ */
+export function wavelengthRange(start: number | null | undefined,
+                                end: number | null | undefined): { start: number, end: number } | null {
+    if (typeof start !== "number" || typeof end !== "number") {
+        return null;
+    }
+    if (!isFinite(start) || !isFinite(end) || start <= 0 || end <= 0) {
+        return null;
+    }
+    return {start: 2 * Math.PI / start, end: 2 * Math.PI / end};
+}


### PR DESCRIPTION
> I'd like to strongly suggest that we add a top axis for our PSDs that shows the real-space size-scale […] I think it's SUPER important for people who are not familiar with PSDs to understand what is being shown.

A PSD is plotted against wavevector, the quantity the mathematics is written in but not the one a reader thinks in. This adds a second axis above the plot showing the wavelength λ = 2π/q, so the size scale a feature appears at can be read straight off the figure.

## Where the decision lives

The axis is offered by `BokehPlot` and driven by the axis label, not hardcoded into the PSD card, so any workflow plotting against a wavevector gets it. The agreed trigger was "any reciprocal x axis"; I had to tighten that in two ways, both unit-tested:

1. **The quantity has to be a wavevector.** A reciprocal length alone is not enough — the curvature distribution is plotted against `µm⁻¹` too (`topobank_statistics/workflows.py:557`), and 2π over a curvature is not a size scale. Without this, that card would have grown a nonsense axis.
2. **The axis has to be logarithmic.** Bokeh links a secondary axis by giving it its own range, and such a link can only express a mapping that is affine in the coordinates the axis is drawn in. `log λ = log 2π − log q` is affine in log space, so a log axis is exact; on a linear axis the same link would *silently* misplace every tick. PSDs are always log, so nothing is lost.

The linked range is recomputed whenever the primary range changes, which covers the initial auto-range as well as zoom, pan and reset. The axis is added before the default style is applied, so it picks up the same fonts and tick formatting as every other axis.

## Testing

* 16 new tests in `frontend/utils/axes.test.ts`: label parsing, reciprocal-unit detection, both rejection cases above, and the range inversion. Full suite green (158).
* **Verified in a headless browser against BokehJS 3.9.2**, since unit tests cannot cover the Bokeh wiring. For wavevectors from 10⁻² to 10² µm⁻¹, the screen position of `q` on the primary axis and of `2π/q` on the secondary agree to four decimal places:

```
q=0.01  screen_q=88.55  screen_lambda=88.55  delta=0.0000
q=0.1   screen_q=241.27 screen_lambda=241.27 delta=0.0000
q=1     screen_q=394.00 screen_lambda=394.00 delta=0.0000
q=10    screen_q=546.73 screen_lambda=546.73 delta=0.0000
q=100   screen_q=699.45 screen_lambda=699.45 delta=0.0000
```

Worth one look at a real PSD card to confirm the label reads well at the site's font size; the mechanics are covered above.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)