### PR TITLE
ENH: Name how much of a measurement is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.34.0 (2026-08-03)
 
+- ENH: The "undefined data" badge of a measurement names how much of it is
+  undefined
+
 - ENH: The publish wizard states on its first step when a dataset cannot be
   published, listing the measurements that are not ready, instead of failing at the
   final "Publish" step

--- a/frontend/components/manager/TopographyBadges.vue
+++ b/frontend/components/manager/TopographyBadges.vue
@@ -2,7 +2,7 @@
 
 import {computed} from "vue";
 
-import {formatExponential} from "@/utils/formatting";
+import {formatExponential, formatPercentage} from "@/utils/formatting";
 import {paperSection} from "@/utils/references";
 import HelpTooltip from "@/components/ui/HelpTooltip.vue";
 
@@ -21,6 +21,22 @@ const isMetadataIncomplete = computed(() => {
 const shortReliabilityCutoff = computed(() => {
     return formatExponential(props.topography.short_reliability_cutoff, 2) + ` m`;
 });
+
+/* How much of the measurement has no value. Older measurements carry no
+   fraction until they are inspected again, in which case the badge says only
+   that there is undefined data, as it did before. */
+const undefinedDataPercentage = computed(() => {
+    return formatPercentage(props.topography?.undefined_data_fraction);
+});
+
+const undefinedDataTooltip = computed(() => {
+    const share = undefinedDataPercentage.value;
+    const extent = share == null
+        ? "Some pixels have no measured value (data gaps)."
+        : `${share} of the pixels have no measured value (data gaps).`;
+    return `${extent} You can choose how to handle these under the Filters tab `
+        + `(leave undefined, or fill by harmonic interpolation).`;
+});
 </script>
 
 <template>
@@ -29,9 +45,10 @@ const shortReliabilityCutoff = computed(() => {
         <span class="badge bg-info ms-2">{{ topography.resolution_x }} &times; {{
                 topography.resolution_y
             }} data points</span>
-        <span v-if="topography.has_undefined_data" class="badge bg-danger ms-2">undefined data
+        <span v-if="topography.has_undefined_data" class="badge bg-danger ms-2">
+            <template v-if="undefinedDataPercentage != null">{{ undefinedDataPercentage }} </template>undefined data
             <HelpTooltip label="About undefined data"
-                text="Some pixels have no measured value (data gaps). You can choose how to handle these under the Filters tab (leave undefined, or fill by harmonic interpolation)."/>
+                :text="undefinedDataTooltip"/>
         </span>
         <span v-if="isMetadataIncomplete" class="badge bg-danger ms-2">metadata incomplete
             <HelpTooltip label="About incomplete metadata"
@@ -48,9 +65,10 @@ const shortReliabilityCutoff = computed(() => {
     <div v-if="topography !== null && topography.resolution_y === null">
         <div class="badge bg-warning ms-1">{{ topography.datafile_format }}</div>
         <div class="badge bg-info ms-2">{{ topography.resolution_x }} data points</div>
-        <span v-if="topography.has_undefined_data" class="badge bg-danger ms-2">undefined data
+        <span v-if="topography.has_undefined_data" class="badge bg-danger ms-2">
+            <template v-if="undefinedDataPercentage != null">{{ undefinedDataPercentage }} </template>undefined data
             <HelpTooltip label="About undefined data"
-                text="Some pixels have no measured value (data gaps). You can choose how to handle these under the Filters tab (leave undefined, or fill by harmonic interpolation)."/>
+                :text="undefinedDataTooltip"/>
         </span>
         <span v-if="isMetadataIncomplete" class="badge bg-danger ms-2">metadata incomplete
             <HelpTooltip label="About incomplete metadata"

--- a/frontend/utils/formatting.test.ts
+++ b/frontend/utils/formatting.test.ts
@@ -5,6 +5,7 @@ import {
     formatDateTime,
     formatDuration,
     formatExponential,
+    formatPercentage,
     preferExponentialLabels,
     prettyBytes,
     unicodeSuperscript
@@ -178,5 +179,28 @@ describe("formatDuration", () => {
         expect(formatDuration(null)).toBe("–");
         expect(formatDuration(undefined)).toBe("–");
         expect(formatDuration("nonsense")).toBe("–");
+    });
+});
+
+describe("formatPercentage", () => {
+    it("formats a fraction as a percentage", () => {
+        expect(formatPercentage(0.07)).toBe("7%");
+        expect(formatPercentage(1)).toBe("100%");
+        expect(formatPercentage(0)).toBe("0%");
+    });
+
+    it("keeps two significant digits", () => {
+        expect(formatPercentage(0.1234)).toBe("12%");
+        expect(formatPercentage(0.001234)).toBe("0.12%");
+    });
+
+    it("does not round a very small share down to nothing", () => {
+        expect(formatPercentage(0.00001)).toBe("< 0.01%");
+    });
+
+    it("has no result for a measurement that has not been inspected", () => {
+        expect(formatPercentage(null)).toBeNull();
+        expect(formatPercentage(undefined)).toBeNull();
+        expect(formatPercentage(NaN)).toBeNull();
     });
 });

--- a/frontend/utils/formatting.ts
+++ b/frontend/utils/formatting.ts
@@ -184,6 +184,29 @@ export function formatDuration(value: number | string | null | undefined): strin
 }
 
 /**
+ * Format a fraction in [0, 1] as a percentage, e.g. 0.07 => "7%".
+ *
+ * Kept to two significant digits: the exact share of undefined pixels in a
+ * measurement carries no more information than its order of magnitude, and a
+ * share far below a percent should still read as something other than "0%".
+ *
+ * @param fraction The fraction to format.
+ * @returns The formatted percentage, or `null` for a missing or non-finite
+ *     value (a measurement that has not been inspected has no fraction).
+ */
+export function formatPercentage(fraction: number | null | undefined): string | null {
+    if (typeof fraction !== "number" || !isFinite(fraction)) {
+        return null;
+    }
+    if (fraction > 0 && fraction < 0.0001) {
+        // Two significant digits would render this as "0%", which reads as
+        // "none" rather than "very little".
+        return "< 0.01%";
+    }
+    return `${formatSignificant(100 * fraction, 2)}%`;
+}
+
+/**
  * Format a date-time string into a human-readable local date-time string.
  *
  * @param dateTimeString The date-time string to be formatted.


### PR DESCRIPTION
Frontend half of #14. The badge said only that a measurement *has* undefined data, which does not distinguish a handful of dropped pixels from a scan that is half missing.

## What this does

* The badge reads "7% undefined data" when the share is known.
* The tooltip names it too ("7% of the pixels have no measured value…").
* `formatPercentage` in `utils/formatting.ts` does the presentation: two significant digits, because the exact share carries no more information than its order of magnitude, and `< 0.01%` rather than `0%` for a share that would otherwise round away to nothing.

The backend reports a fraction rather than a percentage, so the presentation choice lives here.

## Ordering

Needs ContactEngineering/topobank#1378 (the model field) and ContactEngineering/topobank-rest-api#10 (the serializer). Safe to merge in any order: a measurement whose fraction is absent — which includes every measurement inspected before those land — renders exactly as it does today.

## Testing

4 new tests for `formatPercentage`, full suite green (146), `npm run build-dev` clean.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)