### PR TITLE
ENH: Name the trend that detrending subtracted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.34.0 (2026-08-03)
 
+- ENH: The Filters tab names the trend that detrending subtracted, i.e. the slope
+  of the removed tilt and the radius of the removed curvature
+
 - ENH: The publish wizard states on its first step when a dataset cannot be
   published, listing the measurements that are not ready, instead of failing at the
   final "Publish" step

--- a/frontend/components/manager/TopographyUpdateCard.vue
+++ b/frontend/components/manager/TopographyUpdateCard.vue
@@ -20,7 +20,7 @@ import {
 } from 'bootstrap-vue-next';
 
 import {subjectsToBase64} from "@/utils/api";
-import {filterTopographyForPatchRequest} from "@/utils/topography";
+import {describeDetrend, filterTopographyForPatchRequest} from "@/utils/topography";
 import {formatSignificant} from "@/utils/formatting";
 
 import TopographyBadges from "@/components/manager/TopographyBadges.vue";
@@ -124,6 +124,13 @@ const _instrumentChoices = [
     },
     {value: 'contact-based', text: 'Contact-based instrument with known tip radius'}
 ];
+/* The trend the last inspection subtracted, shown only while not editing: the
+   values belong to the mode that was in effect at that inspection, which is not
+   necessarily the one currently selected. */
+const detrendDescription = computed(() => {
+    return describeDetrend(props.topography?.detrend_parameters, props.topography?.unit);
+});
+
 const _detrendChoices = [
     {value: 'center', text: 'No detrending, but subtract mean height'},
     {value: 'height', text: 'Remove tilt'},
@@ -621,6 +628,12 @@ const sizeYModel = croppedSizeModel('size_y');
                                         :class="highlightInput('detrend_mode')"
                                         :disabled="!_editing">
                             </BFormSelect>
+                        </div>
+                        <div v-if="!_editing && detrendDescription != null"
+                             class="form-text mt-0 mb-1">
+                            Removed: {{ detrendDescription }}
+                            <HelpTooltip
+                                text="The trend that was fitted and subtracted when this measurement was last read. Slopes are heights per lateral distance; a radius describes the curvature that was removed."/>
                         </div>
                     </div>
                     <div class="col-6 mt-1">

--- a/frontend/utils/topography.test.ts
+++ b/frontend/utils/topography.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest";
 
-import {emptyTopography, filterTopographyForPatchRequest} from "@/utils/topography";
+import {describeDetrend, emptyTopography, filterTopographyForPatchRequest} from "@/utils/topography";
 
 describe("emptyTopography", () => {
     it("has no server-side representation and no data", () => {
@@ -56,5 +56,40 @@ describe("filterTopographyForPatchRequest", () => {
             height_scale: 1.5,
             is_periodic: true
         });
+    });
+});
+
+describe("describeDetrend", () => {
+    it("names the slope in each lateral direction", () => {
+        expect(describeDetrend({slope_x: 0.0025, slope_y: 0.0071}, "µm"))
+            .toBe("slope 0.0025 in x, slope 0.0071 in y");
+    });
+
+    it("names the radius with the lateral unit", () => {
+        expect(describeDetrend({slope_x: 0.5, radius_x: 50}, "µm"))
+            .toBe("slope 0.5 in x, radius 50 µm in x");
+    });
+
+    it("switches to exponential notation below a thousandth", () => {
+        expect(describeDetrend({slope_x: 2.5e-7}, "µm")).toBe("slope 2.5×10⁻⁷ in x");
+    });
+
+    it("omits what the fit does not determine", () => {
+        // A line scan has no y component, and a flat direction has no radius
+        expect(describeDetrend({slope_x: 0.5}, "µm")).toBe("slope 0.5 in x");
+    });
+
+    it("has no description when no trend was fitted", () => {
+        // A mode that only subtracts the mean
+        expect(describeDetrend({}, "µm")).toBeNull();
+    });
+
+    it("has no description for a measurement that has not been inspected", () => {
+        expect(describeDetrend(null, "µm")).toBeNull();
+        expect(describeDetrend(undefined, "µm")).toBeNull();
+    });
+
+    it("leaves the unit off when the measurement has none", () => {
+        expect(describeDetrend({radius_x: 50}, null)).toBe("radius 50 in x");
     });
 });

--- a/frontend/utils/topography.ts
+++ b/frontend/utils/topography.ts
@@ -1,3 +1,5 @@
+import {formatExponential, formatSignificant} from "@/utils/formatting";
+
 /**
  * Helpers for working with topography (measurement) API objects.
  */
@@ -60,4 +62,45 @@ export function filterTopographyForPatchRequest(topography: any): any {
         }
     }
     return patch;
+}
+
+/**
+ * Describe the trend that detrending subtracted from a measurement.
+ *
+ * The backend fits the trend while reading the file and reports only the
+ * components its detrend mode determines: a measurement that merely has its mean
+ * subtracted has none, a line scan has no y component, and a direction the fit
+ * found to be flat has no radius.
+ *
+ * @param parameters The `detrend_parameters` of the measurement, as reported by
+ *     the API. Null for a measurement that has not been inspected.
+ * @param unit The lateral unit of the measurement, in which radii are given.
+ * @returns A description such as "slope 2.5×10⁻³ in x, radius 50 µm in x", or
+ *     null when no trend was fitted.
+ */
+export function describeDetrend(parameters: any, unit: string | null | undefined): string | null {
+    if (parameters == null) {
+        return null;
+    }
+    const parts: string[] = [];
+    for (const direction of ["x", "y"]) {
+        const slope = parameters[`slope_${direction}`];
+        if (slope != null) {
+            parts.push(`slope ${formatQuantity(slope)} in ${direction}`);
+        }
+    }
+    for (const direction of ["x", "y"]) {
+        const radius = parameters[`radius_${direction}`];
+        if (radius != null) {
+            const withUnit = unit == null ? formatQuantity(radius) : `${formatQuantity(radius)} ${unit}`;
+            parts.push(`radius ${withUnit} in ${direction}`);
+        }
+    }
+    return parts.length === 0 ? null : parts.join(", ");
+}
+
+/* Plain decimals stay readable down to about a thousandth; below that they turn
+   into a row of zeros, which is where the site's exponential notation takes over. */
+function formatQuantity(value: number): string {
+    return Math.abs(value) >= 1e-3 ? formatSignificant(value, 3) : formatExponential(value, 2);
 }


### PR DESCRIPTION
Frontend half of #23. The Filters tab named the detrending *mode* but not what it did, so there was no way to see the tilt or curvature that had been removed.

## What this does

Under the detrending selector: **Removed: slope 2.5×10⁻³ in x, radius 50 µm in x**, with a tooltip explaining that slopes are heights per lateral distance and where the numbers come from.

`describeDetrend` in `utils/topography.ts` builds the description from the fit the backend reports, naming only the components it determines: a measurement that merely has its mean subtracted says nothing, a line scan has no y component, a direction the fit found flat has no radius. Plain decimals stay readable down to a thousandth; below that it switches to the site's exponential notation.

It is shown only while *not* editing, because the values belong to the mode that was in effect at the last inspection, not necessarily the one currently selected in the dropdown.

## Two notes

* **Slopes render as dimensionless numbers, not percentages**, which is a deviation from what I proposed when scoping this. A percentage here would sit directly next to the undefined-data percentage in the same panel and invite confusion, and the exponential notation handles the small magnitudes of real scans better than "0.25%" does. Easy to change if you disagree.
* The logic is a pure function rather than a computed in the component. The first version read `topography.value` inside `TopographyUpdateCard`, where `topography` is a prop — that throws at runtime and the webpack build does not catch it. As a tested function it is covered instead.

## Ordering

Needs ContactEngineering/topobank#1379 and ContactEngineering/topobank-rest-api#11. Safe to merge in any order: without them `detrend_parameters` is absent and the line is not rendered.

## Testing

7 new tests for `describeDetrend`, full suite green (149), `npm run build-dev` clean.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)