### PR TITLE
ENH: One row per dataset, with its other versions offered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.34.0 (2026-08-03)
 
+- ENH: The dataset list shows one row per dataset, naming its version and offering
+  the older ones, instead of a separate row per published version
+
 - ENH: The publish wizard states on its first step when a dataset cannot be
   published, listing the measurements that are not ready, instead of failing at the
   final "Publish" step

--- a/frontend/components/manager/DatasetListRow.vue
+++ b/frontend/components/manager/DatasetListRow.vue
@@ -3,7 +3,8 @@
 import { computed, onMounted, ref } from "vue";
 
 import axios from "axios";
-import { subjectsToBase64 } from "@/utils/api";
+import { getIdFromUrl, subjectsToBase64 } from "@/utils/api";
+import { describeVersions } from "@/utils/versions";
 
 import {
     BBadge,
@@ -25,6 +26,13 @@ const props = defineProps({
 const _creator = ref(null);
 const _publication = ref(null);
 const _downloadModal = ref(null);
+
+/* Older versions of this dataset. The list shows only the latest version, so the
+   others have to be reachable from here; they are fetched when the row is
+   expanded rather than for every row of every page. */
+const _versionsVisible = ref(false);
+const _versions = ref(null);
+const _versionsLoading = ref(false);
 
 /* Download this dataset as a ZIP archive. A published dataset has an archived container that can be fetched straight
    away; everything else is assembled by a Celery worker, with the modal reporting progress. See `DatasetDetail`. */
@@ -50,6 +58,36 @@ onMounted(() => {
         });
     }
 });
+
+const versions = computed(() => {
+    return describeVersions(_versions.value, props.dataset?.version);
+});
+
+function toggleVersions() {
+    _versionsVisible.value = !_versionsVisible.value;
+    if (!_versionsVisible.value || _versions.value != null || _versionsLoading.value) {
+        return;
+    }
+    /* All versions of a dataset share an original, which is what the publication
+       endpoint groups by. */
+    const originalSurface = _publication.value?.original_surface;
+    if (originalSurface == null) {
+        _versions.value = [];
+        return;
+    }
+    _versionsLoading.value = true;
+    axios.get(`/go/publication/?original_surface=${getIdFromUrl(originalSurface)}`)
+        .then(response => {
+            _versions.value = response.data.results ?? response.data;
+        })
+        .catch(() => {
+            // Leave the list empty; the row itself stays usable
+            _versions.value = [];
+        })
+        .finally(() => {
+            _versionsLoading.value = false;
+        });
+}
 
 const publicationAuthorsPretty = computed(() => {
     if (_publication.value == null) {
@@ -128,16 +166,36 @@ const creationDatePretty = computed(() => {
                 <p v-if="dataset.description != null && dataset.description !== ''"
                    class="dataset-description">
                     {{ dataset.description }}</p>
-                <p v-if="dataset.topography_count != null && dataset.version != null"
-                   class="dataset-info">
-                    This is version {{ dataset.version }} of this digital surface twin
-                    and
-                    contains
+                <p v-if="dataset.topography_count != null" class="dataset-info">
+                    This digital surface twin contains
                     {{ dataset.topography_count }} measurements.
                 </p>
-                <p v-else-if="dataset.version != null" class="dataset-info">
-                    This is version {{ dataset.version }} of this digital surface twin.
-                </p>
+                <!-- The list shows only the latest version of a dataset, so say
+                     which one this is and offer the others. -->
+                <div v-if="dataset.version != null" class="dataset-info">
+                    <BBadge variant="secondary">Version {{ dataset.version }}</BBadge>
+                    <BButton v-if="dataset.nb_versions > 1"
+                             class="ms-2 py-0"
+                             size="sm"
+                             variant="outline-secondary"
+                             @click="toggleVersions">
+                        <i :class="_versionsVisible ? 'fa fa-caret-up' : 'fa fa-caret-down'"
+                           class="me-1"></i>{{ dataset.nb_versions }} versions
+                    </BButton>
+                    <div v-if="_versionsVisible" class="mt-1 ms-1">
+                        <span v-if="_versionsLoading">Loading versions&hellip;</span>
+                        <span v-else-if="versions.length === 0">
+                            The other versions of this dataset are not available.
+                        </span>
+                        <ul v-else class="list-unstyled mb-0">
+                            <li v-for="version of versions" :key="version.version">
+                                <a :href="version.href">Version {{ version.version }}</a>
+                                <span v-if="version.date"> &mdash; {{ version.date }}</span>
+                                <span v-if="version.isCurrent" class="text-secondary"> (shown here)</span>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
                 <p v-else-if="dataset.topography_count != null" class="dataset-info">
                     This digital surface twin contains {{ dataset.topography_count }}
                     measurements.

--- a/frontend/utils/versions.test.ts
+++ b/frontend/utils/versions.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it} from "vitest";
+
+import {describeVersions, publicationDate} from "@/utils/versions";
+
+function publication(version: number, surfaceId: number, datetime: string | null = "2024-03-04T05:06:07Z") {
+    return {
+        version: version,
+        datetime: datetime,
+        surface: `http://testserver/manager/api/surface/${surfaceId}/`
+    };
+}
+
+describe("describeVersions", () => {
+    it("orders versions newest first", () => {
+        const versions = describeVersions(
+            [publication(1, 11), publication(3, 13), publication(2, 12)], 3);
+        expect(versions.map(v => v.version)).toEqual([3, 2, 1]);
+    });
+
+    it("links each version to its dataset page", () => {
+        const [version] = describeVersions([publication(2, 42)], 2);
+        expect(version.href).toBe("/ui/dataset-detail/42/");
+    });
+
+    it("marks the version the row shows", () => {
+        const versions = describeVersions([publication(1, 11), publication(2, 12)], 2);
+        expect(versions.map(v => v.isCurrent)).toEqual([true, false]);
+    });
+
+    it("reports the publication date", () => {
+        const [version] = describeVersions([publication(1, 11)], 1);
+        expect(version.date).toBe("2024-03-04");
+    });
+
+    it("tolerates a publication without a date", () => {
+        const [version] = describeVersions([publication(1, 11, null)], 1);
+        expect(version.date).toBeNull();
+    });
+
+    it("skips a publication whose dataset is not readable", () => {
+        const versions = describeVersions(
+            [publication(1, 11), {version: 2, datetime: null, surface: null}], 1);
+        expect(versions.map(v => v.version)).toEqual([1]);
+    });
+
+    it("has no entries before the versions have been fetched", () => {
+        expect(describeVersions(null, 1)).toEqual([]);
+        expect(describeVersions(undefined, 1)).toEqual([]);
+        expect(describeVersions([], 1)).toEqual([]);
+    });
+});
+
+describe("publicationDate", () => {
+    it("keeps the date and drops the time", () => {
+        expect(publicationDate("2024-03-04T05:06:07Z")).toBe("2024-03-04");
+    });
+
+    it("has no result for a missing or unparseable timestamp", () => {
+        expect(publicationDate(null)).toBeNull();
+        expect(publicationDate(undefined)).toBeNull();
+        expect(publicationDate("whenever")).toBeNull();
+    });
+});

--- a/frontend/utils/versions.ts
+++ b/frontend/utils/versions.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers for the published versions of a dataset.
+ *
+ * The dataset list shows only the latest version of a dataset, so a row has to
+ * offer the older ones: publishing creates a separate dataset, and without a way
+ * in from the list they are only reachable by knowing they exist.
+ */
+
+import {getIdFromUrl} from "@/utils/api";
+
+export interface DatasetVersion {
+    /** Version number, as published. */
+    version: number;
+    /** Publication date, `YYYY-MM-DD`, or null if the publication carries none. */
+    date: string | null;
+    /** Link to the dataset page of this version. */
+    href: string;
+    /** Whether this is the version the row itself shows. */
+    isCurrent: boolean;
+}
+
+/**
+ * Turn the publications of a dataset into the entries of the version list,
+ * newest first.
+ *
+ * @param publications Publications as returned by the publication API, i.e.
+ *     carrying `version`, `datetime` and a `surface` URL.
+ * @param currentVersion The version the row shows, marked in the result.
+ * @returns One entry per publication, ordered from newest to oldest.
+ */
+export function describeVersions(publications: any[] | null | undefined,
+                                 currentVersion: number | null | undefined): DatasetVersion[] {
+    if (publications == null) {
+        return [];
+    }
+    return publications
+        .filter(publication => publication?.surface != null)
+        .map(publication => ({
+            version: publication.version,
+            date: publicationDate(publication.datetime),
+            href: `/ui/dataset-detail/${getIdFromUrl(publication.surface)}/`,
+            isCurrent: publication.version === currentVersion
+        }))
+        .sort((a, b) => b.version - a.version);
+}
+
+/**
+ * The date part of a publication timestamp.
+ *
+ * @param datetime An ISO timestamp, as the API reports it.
+ * @returns The date as `YYYY-MM-DD`, or null if there is none to show.
+ */
+export function publicationDate(datetime: string | null | undefined): string | null {
+    if (datetime == null) {
+        return null;
+    }
+    const date = new Date(datetime);
+    return isNaN(date.getTime()) ? null : date.toISOString().substring(0, 10);
+}


### PR DESCRIPTION
> When I search "UNCD", I get one result at the top of the list called "Ultrananocrystalline diamond (UNCD)" (which is version 1) and I get a separate one way down at the bottom of the list with the same name, which is version 2. […] most people will click the first one they find.

Frontend half of #38, implementing the "group versions in one result row" option.

## What this does

The backend now lists only the latest version of each published dataset. This row:

* names the version in a badge, replacing the grey "This is version 1 of this digital surface twin" note that the issue calls out as very easy to miss;
* offers the older versions behind a **3 versions** button, which expands to a list linking to each of them with its publication date, marking the one shown.

The versions are fetched when a row is expanded rather than for every row of every page. All versions share an original, which is what the publication endpoint groups by, and the row already knows it from the publication it fetches anyway — so expanding costs one request. A failed request leaves the list empty and says so rather than breaking the row.

This keeps the comparison you were worried about in the original discussion: older versions are still reachable, now from the list itself rather than only from the detail page.

## Ordering

Needs ContactEngineering/topobank-rest-api#12 (the collapsing) and ContactEngineering/topobank-publication#48 (`version`/`nb_versions`). Safe to merge in any order: without them `nb_versions` is absent, so the button is not rendered, and the list behaves as it does today.

## Testing

9 new tests for `utils/versions.ts` (ordering, links, the current marker, dates, an unreadable version, and the not-yet-fetched state). Full suite green (151), `npm run build-dev` clean.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)