### PR TITLE
Performance: fewer requests, throttled card rebuilds, calmer polling (phase 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog for plugin *ce-ui*
 
+## 1.35.0 (2026-08-04)
+
+- ENH: Analysis cards refresh at most once every ten seconds while a batch of
+  tasks is running (plus a final refresh when the batch completes), instead of
+  rebuilding the whole card - server round-trip, data-series downloads and all -
+  for every single task that finished
+- ENH: The dataset list renders thumbnails from the data it already has instead
+  of every row fetching its measurements from the API again; thumbnails load
+  lazily so off-screen rows don't compete for connections
+- ENH: Plots use the canvas renderer in production; the SVG renderer built one
+  DOM subtree per curve, which froze the page on analyses over large dataset
+  collections. Plot downloads are PNG accordingly, and the menu entry says so
+- ENH: Notifications are polled every 30 seconds instead of every second, and
+  not at all from background tabs
+- ENH: Task-status rows back off their polling from 5 to at most 30 seconds
+  while a task runs; measurement cards poll every 3 seconds instead of every
+  second
+- MAINT: Database connections are reused across requests in production
+  (`CONN_MAX_AGE`, env-overridable, with health checks) instead of reconnecting
+  per request
+- MAINT: Presigned storage URLs live for a day instead of an hour, so
+  thumbnails and plot data on a page left open no longer break after an hour
+- MAINT: The request profiler no longer records the notification poll, which
+  inserted a profiling row per request without ever being the request under
+  investigation
+- BUG: Task-finished events are emitted from a watcher instead of a computed
+  getter, and the "load more thumbnails" over-fetch (limit growing with offset)
+  is gone
+
 ## 1.34.0 (2026-08-03)
 
 - ENH: The dataset list shows one row per dataset, naming its version and offering

--- a/ce_ui/settings/base.py
+++ b/ce_ui/settings/base.py
@@ -443,6 +443,13 @@ AWS_DEFAULT_ACL = None
 # Append extra characters if new files have the same name
 AWS_S3_FILE_OVERWRITE = False
 
+# Lifetime of presigned URLs. The django-storages default of one hour means
+# thumbnails and plot data on a page left open start returning 403 after an
+# hour. Note that longer expiry does not make the URLs cacheable: every
+# response signs URLs afresh (a fix that requires serving derived files from
+# stable, publicly cacheable URLs).
+AWS_QUERYSTRING_EXPIRE = env.int("AWS_QUERYSTRING_EXPIRE", default=86400)
+
 # STATIC
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
@@ -697,9 +704,13 @@ TABNAV_DISPLAY_HOME_TAB = True
 
 # REQUEST PROFILER
 # ------------------------------------------------------------------------------
-# Default configuration is to ingore staff user, we override this here to log all requests
-def REQUEST_PROFILER_GLOBAL_EXCLUDE_FUNC(x):
-    return True
+# Default configuration is to ignore staff users, we override this here to log
+# all requests. High-frequency polling endpoints are excluded: each profiled
+# request is an INSERT into a large table, and the notification poll runs
+# continuously from every open tab of every logged-in user without ever being
+# the request whose timing anyone investigates.
+def REQUEST_PROFILER_GLOBAL_EXCLUDE_FUNC(request):
+    return not request.path.startswith("/inbox/notifications/")
 
 
 # Keep records for a month

--- a/ce_ui/settings/production.py
+++ b/ce_ui/settings/production.py
@@ -14,7 +14,12 @@ DEBUG = False
 
 # DATABASES
 # ------------------------------------------------------------------------------
-DATABASES["default"]["CONN_MAX_AGE"] = env.int("CONN_MAX_AGE", default=0)  # noqa F405
+# Keep database connections alive between requests. The default of 0 opens a
+# new Postgres connection for every request; pages of the single-page frontend
+# fan out into dozens of API requests, so connection setup is pure overhead.
+DATABASES["default"]["CONN_MAX_AGE"] = env.int("CONN_MAX_AGE", default=60)  # noqa F405
+# Guard reused connections against having been closed by the server
+DATABASES["default"]["CONN_HEALTH_CHECKS"] = True  # noqa F405
 
 # SECURITY
 # ------------------------------------------------------------------------------
@@ -165,7 +170,11 @@ LOGGING = {
 # - 'svg': Render using SVG. Plot will download as SVG if this is enabled while they download as PNG in the 'canvas'
 #   backend. SVG has problems with zooming plots.
 # - 'webgl': Accelerates some plots using WebGL
-BOKEH_OUTPUT_BACKEND = "svg"
+# The SVG backend creates one DOM subtree per glyph; a PSD/ACF plot over a
+# large dataset collection has hundreds of line glyphs and legend entries,
+# which freezes the page long after the data has arrived. Canvas handles that
+# size comfortably; the trade-off is that plots download as PNG instead of SVG.
+BOKEH_OUTPUT_BACKEND = env.str("BOKEH_OUTPUT_BACKEND", default="canvas")
 
 # Settings for watchman
 # WATCHMAN_AUTH_DECORATOR = 'watchman.decorators.token_required'

--- a/frontend/components/analysis/ContactMechanicsCard.vue
+++ b/frontend/components/analysis/ContactMechanicsCard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 
 import axios from "axios";
-import { computed, onMounted, ref } from "vue";
+import throttle from "lodash/throttle";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 import { BDropdownDivider, BDropdownItem, BTab, BTabs, useToastController } from "bootstrap-vue-next";
 
@@ -77,6 +78,17 @@ const activeTab = useActiveTab("contact-mechanics-card");
 
 onMounted(() => {
     updateCard();
+});
+
+/* While a batch of tasks drains, every single task that finishes reports
+   "some tasks finished". Rebuilding the card is expensive (the server
+   re-serializes every analysis and the browser re-fetches every data series),
+   so partial completions are coalesced into at most one refresh per interval;
+   the final refresh comes from `allTasksFinished`, which is not throttled. */
+const updateCardThrottled = throttle(() => updateCard(), 10000, {leading: false, trailing: true});
+
+onBeforeUnmount(() => {
+    updateCardThrottled.cancel();
 });
 
 function updateCard() {
@@ -298,7 +310,7 @@ function downloadZip() {
                   title="Contact mechanics"
                   @allTasksFinished="updateCard"
                   @refreshButtonClicked="updateCard"
-                  @someTasksFinished="updateCard">
+                  @someTasksFinished="updateCardThrottled">
         <template #dropdowns>
             <BDropdownDivider></BDropdownDivider>
             <BDropdownItem @click="_parametersVisible = true">
@@ -313,7 +325,8 @@ function downloadZip() {
                     Download ZIP
                 </BDropdownItem>
                 <BDropdownItem @click="_plot.download()">
-                    Download SVG
+                    <!-- The save format follows the Bokeh output backend -->
+                    Download {{ _outputBackend === 'svg' ? 'SVG' : 'PNG' }}
                 </BDropdownItem>
             </template>
         </template>

--- a/frontend/components/analysis/RoughnessParametersCard.vue
+++ b/frontend/components/analysis/RoughnessParametersCard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 
 import axios from "axios";
-import { computed, onMounted, ref } from "vue";
+import throttle from "lodash/throttle";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 import { BDropdownDivider, BDropdownItem, useToastController } from "bootstrap-vue-next";
 
@@ -91,6 +92,17 @@ onMounted(() => {
     updateCard();
 });
 
+/* While a batch of tasks drains, every single task that finishes reports
+   "some tasks finished". Rebuilding the card is expensive (the server reads
+   every analysis result), so partial completions are coalesced into at most
+   one refresh per interval; the final refresh comes from `allTasksFinished`,
+   which is not throttled. */
+const updateCardThrottled = throttle(updateCard, 10000, {leading: false, trailing: true});
+
+onBeforeUnmount(() => {
+    updateCardThrottled.cancel();
+});
+
 const hasData = computed(() => {
     return _data.value != null && _data.value.length > 0;
 });
@@ -154,7 +166,7 @@ function updateCard() {
                   :title="_title"
                   @allTasksFinished="updateCard"
                   @refreshButtonClicked="updateCard"
-                  @someTasksFinished="updateCard">
+                  @someTasksFinished="updateCardThrottled">
         <template #dropdowns>
             <template v-if="hasData">
                 <BDropdownDivider></BDropdownDivider>

--- a/frontend/components/analysis/SeriesCard.vue
+++ b/frontend/components/analysis/SeriesCard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 
 import axios from "axios";
-import { computed, onMounted, ref } from "vue";
+import throttle from "lodash/throttle";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 import { BDropdownDivider, BDropdownItem, useToastController } from "bootstrap-vue-next";
 
@@ -74,6 +75,17 @@ const _messages = ref([]);
 
 onMounted(() => {
     updateCard();
+});
+
+/* While a batch of tasks drains, every single task that finishes reports
+   "some tasks finished". Rebuilding the card is expensive (the server
+   re-serializes every analysis and the browser re-fetches every data series),
+   so partial completions are coalesced into at most one refresh per interval;
+   the final refresh comes from `allTasksFinished`, which is not throttled. */
+const updateCardThrottled = throttle(updateCard, 10000, {leading: false, trailing: true});
+
+onBeforeUnmount(() => {
+    updateCardThrottled.cancel();
 });
 
 const hasData = computed(() => {
@@ -180,7 +192,7 @@ async function downloadData(fileFormat) {
                   :title="_title"
                   @allTasksFinished="updateCard"
                   @refreshButtonClicked="updateCard"
-                  @someTasksFinished="updateCard">
+                  @someTasksFinished="updateCardThrottled">
         <template #dropdowns>
             <template v-if="hasData">
                 <BDropdownDivider></BDropdownDivider>
@@ -191,7 +203,8 @@ async function downloadData(fileFormat) {
                     Download CSV
                 </BDropdownItem>
                 <BDropdownItem @click="_plot.download()">
-                    Download SVG
+                    <!-- The save format follows the Bokeh output backend -->
+                    Download {{ _outputBackend === 'svg' ? 'SVG' : 'PNG' }}
                 </BDropdownItem>
             </template>
         </template>

--- a/frontend/components/analysis/TaskStateRow.vue
+++ b/frontend/components/analysis/TaskStateRow.vue
@@ -16,7 +16,11 @@ const analysis = defineModel('analysis', {required: true});
 const props = defineProps({
     pollingInterval: {
         type: Number,
-        default: 2000  // milliseconds
+        default: 5000  // milliseconds
+    },
+    maxPollingInterval: {
+        type: Number,
+        default: 30000  // milliseconds
     }
 });
 
@@ -24,6 +28,11 @@ const _error = ref(null);
 const _function = ref(null);
 const _subject = ref(null);
 let _timeoutID = null;
+
+/* Poll quickly at first, then back off: short tasks report promptly, while a
+   long-running task is not hammered with a request every few seconds by every
+   open row. Reset when the user renews the task. */
+let _currentPollingInterval = props.pollingInterval;
 
 onMounted(() => {
     scheduleStateCheck();
@@ -69,7 +78,9 @@ function scheduleStateCheck() {
 
     if (analysis.value.task_state == null || analysis.value.task_state === 'pe' || analysis.value.task_state === 'st') {
         if (_timeoutID == null) {
-            _timeoutID = setTimeout(checkState, props.pollingInterval);
+            _timeoutID = setTimeout(checkState, _currentPollingInterval);
+            _currentPollingInterval = Math.min(
+                _currentPollingInterval * 1.5, props.maxPollingInterval);
         }
     } else if (analysis.value.task_state === 'fa') {
         // This is a failure. Query reason.
@@ -106,6 +117,7 @@ function checkState() {
 }
 
 function renew() {
+    _currentPollingInterval = props.pollingInterval;
     analysis.value.task_state = 'pe';
     // A PUT request triggers renewal of the analysis
     axios.put(analysis.value.url).then(response => {

--- a/frontend/components/analysis/TasksButton.vue
+++ b/frontend/components/analysis/TasksButton.vue
@@ -1,6 +1,6 @@
 <script setup>
 
-import {computed, ref} from "vue";
+import {computed, ref, watch} from "vue";
 
 import {BButton} from 'bootstrap-vue-next';
 
@@ -18,22 +18,20 @@ const emit = defineEmits(['allTasksFinished', 'someTasksFinished']);
 const _modalVisible = ref(false);
 
 // Number of running or pending tasks
-let _lastNbRunningOrPending = null;
 const nbRunningOrPending = computed(() => {
-    const currentNbRunningOrPending = countTaskStates(analyses.value, ['pe', 'st', 're']);
-    // FIXME: side-effect (emit) inside a computed getter. Emitting events from a computed getter is fragile —
-    // the getter runs on every dependency read/re-evaluation, so events fire at unpredictable times. This should
-    // be refactored to a watcher, but that is a higher-risk change handled in a separate pass.
-    // Emit event when all tasks are finished
-    if (_lastNbRunningOrPending !== null && _lastNbRunningOrPending > 0) {
-        if (currentNbRunningOrPending === 0) {
-            emit('allTasksFinished', currentNbRunningOrPending);
-        } else if (currentNbRunningOrPending < _lastNbRunningOrPending) {
-            emit('someTasksFinished', currentNbRunningOrPending);
+    return countTaskStates(analyses.value, ['pe', 'st', 're']);
+});
+
+// Tell the parent when tasks finish. A watcher only fires when the count
+// actually changes, so parents can safely react by re-fetching data.
+watch(nbRunningOrPending, (current, previous) => {
+    if (previous > 0) {
+        if (current === 0) {
+            emit('allTasksFinished', current);
+        } else if (current < previous) {
+            emit('someTasksFinished', current);
         }
     }
-    _lastNbRunningOrPending = currentNbRunningOrPending;
-    return currentNbRunningOrPending;
 });
 
 // Number of successful tasks

--- a/frontend/components/layout/NotificationOffcanvas.vue
+++ b/frontend/components/layout/NotificationOffcanvas.vue
@@ -22,7 +22,11 @@ const props = defineProps({
     },
     pollingInterval: {
         type: Number,
-        default: 1000  // milliseconds
+        // Notifications are ambient information: a half-minute delay is
+        // imperceptible, while polling every second from every open tab of
+        // every logged-in user was the single largest source of requests on
+        // the site.
+        default: 30000  // milliseconds
     },
 });
 
@@ -43,6 +47,11 @@ onBeforeUnmount(() => {
 });
 
 function updateNotifications() {
+    // Background tabs don't need fresh notifications; they catch up on the
+    // next tick after becoming visible again
+    if (document.hidden) {
+        return;
+    }
     axios.get(props.apiUrl)
         .then(response => {
             unreadCount.value = response.data.unread_count;

--- a/frontend/components/manager/DatasetListRow.vue
+++ b/frontend/components/manager/DatasetListRow.vue
@@ -151,7 +151,7 @@ const creationDatePretty = computed(() => {
                     This digital surface twin was published by {{ publicationAuthorsPretty }} on {{ publicationDatePretty }}
                 </p>
                 <ThumbnailRow class="mb-3"
-                              :data-source-list-url="dataset.topographies">
+                              :data-sources="dataset.topography_set">
                 </ThumbnailRow>
                 <p v-if="_publication == null" class="dataset-authors">
                     This digital surface twin is unpublished.

--- a/frontend/components/manager/Thumbnail.vue
+++ b/frontend/components/manager/Thumbnail.vue
@@ -32,9 +32,14 @@ const hasThumbnail = computed(() => {
            :title="hasFailed ? 'Processing of this measurement failed' : dataSource.name">
             <i v-if="hasFailed"
                :class="`fa-solid fa-triangle-exclamation fa-2x text-danger ${imgClass}`"></i>
+            <!-- Lazy loading keeps off-screen rows from competing with the
+                 visible ones for the browser's connection budget -->
             <img v-else-if="hasThumbnail"
                  :class="imgClass"
                  :src="dataSource.thumbnail.file"
+                 :alt="dataSource.name"
+                 loading="lazy"
+                 decoding="async"
                  @load="_isLoading = false"
                  @error="_isLoading = false">
             <i v-else

--- a/frontend/components/manager/ThumbnailRow.vue
+++ b/frontend/components/manager/ThumbnailRow.vue
@@ -1,58 +1,47 @@
 <script setup lang="ts">
 
-import axios from "axios";
-import {onMounted, ref} from "vue";
+import {computed, ref} from "vue";
 
-import {BButton, BOverlay} from "bootstrap-vue-next";
+import {BButton} from "bootstrap-vue-next";
 
 import Thumbnail from "@/components/manager/Thumbnail.vue";
 
+/* The dataset list response already contains every measurement of every
+   dataset (`topography_set`), so the thumbnails are rendered from that data
+   instead of each row fetching its measurements again from the API. */
 const props = defineProps({
-    dataSourceListUrl: String,
+    dataSources: {
+        type: Array,
+        default: () => []
+    },
     nbThumbnailsIncrement: {
         type: Number,
         default: 5
     }
 });
 
-const _dataSources = ref([]);
-const _nbDataSources = ref<number>(0);
-const _nbThumbnails = ref<number>(0);
-const _isLoading = ref<boolean>(true);
+const _nbVisible = ref<number>(props.nbThumbnailsIncrement);
 
-onMounted(() => {
-    loadMoreThumbnails();
+const visibleDataSources = computed(() => {
+    return props.dataSources.slice(0, _nbVisible.value);
 });
-
-function loadMoreThumbnails() {
-    _isLoading.value = true;
-    axios.get(`${props.dataSourceListUrl}&offset=${_nbThumbnails.value}&limit=${_nbThumbnails.value + props.nbThumbnailsIncrement}`)
-        .then(response => {
-            _dataSources.value.push(...response.data.results);
-            _nbDataSources.value = response.data.count;
-            _nbThumbnails.value += props.nbThumbnailsIncrement;
-        })
-        .finally(() => {
-            _isLoading.value = false;
-        });
-}
 
 </script>
 
 <template>
-    <BOverlay class="thumbnail-row" :show="_isLoading">
-        <Thumbnail v-for="dataSource in _dataSources"
+    <div class="thumbnail-row">
+        <Thumbnail v-for="dataSource in visibleDataSources"
                    :key="dataSource.id"
                    class="me-1"
                    img-class="mh-100"
                    :data-source="dataSource">
         </Thumbnail>
-        <BButton v-if="_nbDataSources > _dataSources.length"
+        <BButton v-if="dataSources.length > _nbVisible"
                  variant="light" size="sm" class="me-1"
-                 @click="loadMoreThumbnails">
+                 @click="_nbVisible += nbThumbnailsIncrement">
             <i class="fa fa-ellipsis align-self-center"></i>
         </BButton>
-    </BOverlay>
+    </div>
 </template>
 
 <style scoped>

--- a/frontend/components/manager/TopographyCard.vue
+++ b/frontend/components/manager/TopographyCard.vue
@@ -19,7 +19,10 @@ const props = defineProps({
     },
     pollingInterval: {
         type: Number,
-        default: 1000  // milliseconds
+        // Every pending measurement on the dataset page polls its own state;
+        // one request per second per measurement adds up quickly during bulk
+        // uploads
+        default: 3000  // milliseconds
     },
     selectable: {
         type: Boolean,


### PR DESCRIPTION
First phase of the performance work discussed for the sluggish list-view thumbnails and slow PSD/ACF visualization over large dataset collections. This phase is ce-ui-only (frontend + settings); no API changes.

## Analysis cards: at most one rebuild per 10 s while tasks drain

Every finishing task emitted `someTasksFinished`, and the cards responded by re-requesting the entire card — a server round-trip that re-serializes every analysis, followed by the browser re-fetching every data series. With ~100 analyses draining one by one this meant up to ~100 full rebuilds, which is a large part of why PSD/ACF over many datasets took minutes. Partial completions are now coalesced into at most one refresh per 10 s (trailing-edge throttle, cancelled on unmount); the final refresh on batch completion and the manual refresh button stay immediate. The finished events are also emitted from a watcher instead of a computed getter, resolving the FIXME in `TasksButton.vue`.

## Dataset list: thumbnails from data already in hand

The surface list response already contains every measurement (`topography_set`), but each row fetched its measurements again from the API just to discover thumbnail URLs — 10 extra XHRs per page queueing ahead of the image fetches on the browser's per-host connection budget, which is what the 1–5 s thumbnail delay was. `ThumbnailRow` now renders from the list response, the "more" button reveals already-loaded entries client-side (also fixing its `limit = offset + increment` over-fetch), and images load lazily with async decoding.

## Calmer polling

- Notifications: 1 s → 30 s, and skipped in background tabs. This was the single largest request source on the site (one request per second per open tab per logged-in user).
- Analysis task rows: 5 s with ×1.5 backoff capped at 30 s, reset on renew (was a fixed 2 s).
- Measurement cards on the dataset page: 3 s (was 1 s).

## Production settings

- `CONN_MAX_AGE=60` with health checks (env-overridable) — pages fan out into dozens of API requests, each of which paid for a fresh Postgres connection.
- `BOKEH_OUTPUT_BACKEND` now defaults to `canvas` (env-overridable). The SVG backend builds one DOM subtree per glyph, which froze the page on plots with hundreds of curves. **Note:** plot downloads become PNG instead of SVG; the menu entry now names the actual format. Set `BOKEH_OUTPUT_BACKEND=svg` to restore SVG export.
- The request profiler no longer records the notification poll (one INSERT per request into the ~1 GB profiling table, for a request nobody investigates).
- `AWS_QUERYSTRING_EXPIRE=86400` (env-overridable) — presigned URLs on a page left open no longer 403 after an hour. This fixes breakage, not cacheability; stable cacheable URLs for derived files are phase 1.

## Testing

- `vitest run`: 178 tests, all passing
- `webpack --mode development` compiles with only the pre-existing sass deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY)_