### PR TITLE
Dataset list on the v2 API + browser-cacheable file URLs (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog for plugin *ce-ui*
 
+## 1.36.0 (2026-08-04)
+
+- ENH: The dataset list runs on the v2 API and renders each page from a single
+  response: creator names, publication details (DOI, license, authors) and
+  measurement thumbnails arrive embedded, replacing the two to three requests
+  every row used to make on its own
+- ENH: Presigned storage URLs are memoized for half their lifetime
+  (`ce_ui.storage.CachedPresignedUrlStorage`), so the URL for a thumbnail, a
+  plot data series or a deep-zoom tile stays the same between page loads and
+  browsers can serve it from their cache instead of re-downloading it
+- ENH: Uploaded objects carry a `Cache-Control` header matching that window
+- ENH: The "Created by you" / "shared with you" badges on dataset rows work
+  again; they relied on a `sharing_status` field that no API version reported
+
 ## 1.35.0 (2026-08-04)
 
 - ENH: Analysis cards refresh at most once every ten seconds while a batch of

--- a/ce_ui/settings/base.py
+++ b/ce_ui/settings/base.py
@@ -450,6 +450,16 @@ AWS_S3_FILE_OVERWRITE = False
 # stable, publicly cacheable URLs).
 AWS_QUERYSTRING_EXPIRE = env.int("AWS_QUERYSTRING_EXPIRE", default=86400)
 
+# Stored on every uploaded object and echoed by S3 in GET responses. Files in
+# the data lake are immutable (replacing one means a new manifest under a new
+# path), so browsers may cache them; 'private' keeps shared proxies out of it.
+# The max-age matches the presigned-URL memoization window (half the URL
+# lifetime, see ce_ui.storage.CachedPresignedUrlStorage) — beyond that the URL
+# changes and the cache entry would never be hit again anyway.
+AWS_S3_OBJECT_PARAMETERS = {
+    "CacheControl": f"private, max-age={AWS_QUERYSTRING_EXPIRE // 2}",
+}
+
 # STATIC
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root

--- a/ce_ui/settings/production.py
+++ b/ce_ui/settings/production.py
@@ -200,7 +200,9 @@ MIDDLEWARE.insert(  # noqa: F405
 # ------------------------------------------------------------------------------
 USE_S3_STORAGE = True
 STORAGES = {
-    "default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"},
+    # Memoizes presigned URLs so browsers can cache thumbnails, plot data and
+    # deep-zoom tiles between page loads; see ce_ui.storage
+    "default": {"BACKEND": "ce_ui.storage.CachedPresignedUrlStorage"},
     "staticfiles": {
         "BACKEND": "servestatic.storage.CompressedManifestStaticFilesStorage"
     },

--- a/ce_ui/storage.py
+++ b/ce_ui/storage.py
@@ -1,0 +1,40 @@
+"""Storage backends."""
+
+from django.core.cache import cache
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class CachedPresignedUrlStorage(S3Boto3Storage):
+    """S3 storage that memoizes presigned URLs.
+
+    Signing is cheap, but a fresh signature per response means the URL for the
+    same object differs between page loads, so browsers can never serve it
+    from their cache and re-download thumbnails, plot data and deep-zoom tiles
+    on every visit. Handing out the same signed URL for half its lifetime lets
+    repeat requests hit the browser cache instead of the object store.
+
+    Files in the data lake are immutable — replacing a file means creating a
+    new manifest under a new storage path — so a memoized URL can never point
+    at stale content. Note that a signed URL stays valid for its full lifetime
+    regardless of later permission changes; memoization does not change that,
+    it only means the window is used rather than wasted.
+    """
+
+    def url(self, name, parameters=None, expire=None, http_method=None):
+        if parameters or expire or http_method:
+            # Requests with special parameters are signed fresh
+            return super().url(
+                name, parameters=parameters, expire=expire, http_method=http_method
+            )
+        if not self.querystring_auth:
+            # Unsigned URLs are stable already
+            return super().url(name)
+        cache_key = f"presigned-url:{self.location}:{name}"
+        url = cache.get(cache_key)
+        if url is None:
+            url = super().url(name)
+            # Serve the same URL for half its lifetime, so that a URL handed
+            # out at the end of the memoization window is still valid for at
+            # least the other half.
+            cache.set(cache_key, url, timeout=max(self.querystring_expire // 2, 60))
+        return url

--- a/frontend/components/layout/SelectionOffcanvas.vue
+++ b/frontend/components/layout/SelectionOffcanvas.vue
@@ -52,7 +52,7 @@ onMounted(async () => {
 
 async function refreshDatasets() {
     datasets.value = (await Promise.all(selection.datasetIds.map(async (id) => {
-        return axios.get("/manager/api/surface/" + id);
+        return axios.get("/manager/v2/surface/" + id + "/");
     }))).map(response => {
         return response.data;
     });

--- a/frontend/components/manager/DatasetListRow.vue
+++ b/frontend/components/manager/DatasetListRow.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import { computed, onMounted, ref } from "vue";
+import { computed, ref } from "vue";
 
 import axios from "axios";
 import { getIdFromUrl, subjectsToBase64 } from "@/utils/api";
@@ -23,8 +23,10 @@ const props = defineProps({
     dataset: Object
 });
 
-const _creator = ref(null);
-const _publication = ref(null);
+/* The v2 list response embeds the creator's name and a publication summary,
+   so a row makes no requests of its own. */
+const _creator = computed(() => props.dataset?.created_by?.name ?? null);
+const _publication = computed(() => props.dataset?.publication ?? null);
 const _downloadModal = ref(null);
 
 /* Older versions of this dataset. The list shows only the latest version, so the
@@ -46,18 +48,6 @@ function download() {
         props.dataset.api.async_download,
         {title: `Download '${props.dataset.name}'`});
 }
-
-onMounted(() => {
-    axios.get(props.dataset.creator)
-        .then(response => {
-            _creator.value = response.data.name;
-        });
-    if (props.dataset?.publication) {
-        axios.get(props.dataset.publication).then(response => {
-            _publication.value = response.data;
-        });
-    }
-});
 
 const versions = computed(() => {
     return describeVersions(_versions.value, props.dataset?.version);
@@ -101,7 +91,7 @@ const publicationDatePretty = computed(() => {
 });
 
 const creationDatePretty = computed(() => {
-    return new Date(props.dataset.creation_datetime).toISOString().substring(0, 10);
+    return new Date(props.dataset.created_at).toISOString().substring(0, 10);
 });
 
 </script>
@@ -123,13 +113,6 @@ const creationDatePretty = computed(() => {
                         :href="`https://doi.org/${_publication.doi_name}`">
                     https://doi.org/{{ _publication.doi_name }}
                 </BBadge>
-                <a v-if="dataset.publication_doi != null"
-                   class="badge bg-dark me-1 text-decoration-none"
-                   :href="dataset.publication_doi">{{ dataset.publication_doi }}</a>
-                <img v-if="dataset.publication_license != null"
-                     :src="`/static/images/cc/${dataset.publication_license}.svg`"
-                     title="Dataset can be reused under the terms of a Creative Commons license."
-                     style="float:right">
                 <p v-if="dataset.sharing_status === 'own'" class='badge bg-info me-1'>
                     Created by you
                 </p>
@@ -151,7 +134,7 @@ const creationDatePretty = computed(() => {
                     This digital surface twin was published by {{ publicationAuthorsPretty }} on {{ publicationDatePretty }}
                 </p>
                 <ThumbnailRow class="mb-3"
-                              :data-sources="dataset.topography_set">
+                              :data-sources="dataset.topographies">
                 </ThumbnailRow>
                 <p v-if="_publication == null" class="dataset-authors">
                     This digital surface twin is unpublished.
@@ -159,16 +142,16 @@ const creationDatePretty = computed(() => {
                     <span v-if="_creator != null">
                         by {{ _creator }}
                     </span>
-                    <span v-if="dataset.creation_datetime != null">
+                    <span v-if="dataset.created_at != null">
                         on {{ creationDatePretty }}
                     </span>.
                 </p>
                 <p v-if="dataset.description != null && dataset.description !== ''"
                    class="dataset-description">
                     {{ dataset.description }}</p>
-                <p v-if="dataset.topography_count != null" class="dataset-info">
+                <p v-if="dataset.topographies != null" class="dataset-info">
                     This digital surface twin contains
-                    {{ dataset.topography_count }} measurements.
+                    {{ dataset.topographies.length }} measurements.
                 </p>
                 <!-- The list shows only the latest version of a dataset, so say
                      which one this is and offer the others. -->
@@ -196,10 +179,6 @@ const creationDatePretty = computed(() => {
                         </ul>
                     </div>
                 </div>
-                <p v-else-if="dataset.topography_count != null" class="dataset-info">
-                    This digital surface twin contains {{ dataset.topography_count }}
-                    measurements.
-                </p>
             </div>
             <div class="d-block">
                 <BButtonGroup vertical size="sm">

--- a/frontend/components/manager/Thumbnail.vue
+++ b/frontend/components/manager/Thumbnail.vue
@@ -20,8 +20,14 @@ const hasFailed = computed(() => {
     return props.dataSource.task_state === 'fa';
 });
 
+/* The v2 measurement summary carries a flat `thumbnail_url`; the full v1
+   topography representation nests it as `thumbnail.file`. */
+const thumbnailUrl = computed(() => {
+    return props.dataSource.thumbnail_url ?? props.dataSource.thumbnail?.file ?? null;
+});
+
 const hasThumbnail = computed(() => {
-    return props.dataSource.thumbnail != null && props.dataSource.thumbnail.file != null;
+    return thumbnailUrl.value != null;
 });
 
 </script>
@@ -36,7 +42,7 @@ const hasThumbnail = computed(() => {
                  visible ones for the browser's connection budget -->
             <img v-else-if="hasThumbnail"
                  :class="imgClass"
-                 :src="dataSource.thumbnail.file"
+                 :src="thumbnailUrl"
                  :alt="dataSource.name"
                  loading="lazy"
                  decoding="async"

--- a/frontend/pages/DatasetList.vue
+++ b/frontend/pages/DatasetList.vue
@@ -29,7 +29,7 @@ const selection = useDatasetSelectionStore();
 const props = defineProps({
     apiUrl: {
         type: String,
-        default: "/manager/api/surface/"
+        default: "/manager/v2/surface/"
     },
     currentPage: {
         Number,
@@ -50,9 +50,9 @@ const props = defineProps({
     }
 });
 
-// Constants
+// Constants; the values are v2 `order` parameters
 const orderByFilterChoices = [
-    {text: 'Date', value: 'date'},
+    {text: 'Date', value: '-created_at'},
     {text: 'Name', value: 'name'},
 ];
 const sharingStatusFilterChoices = [
@@ -103,8 +103,10 @@ function getDatasets(offset: number = 0) {
     _isLoading.value = true;
     _currentPage.value = offset / _pageSize.value + 1;
     let queryUrl = `${props.apiUrl}?offset=${offset}&limit=${_pageSize.value}`;
-    queryUrl += `&order_by=${_orderBy.value}`;
+    queryUrl += `&order=${_orderBy.value}`;
     queryUrl += `&sharing_status=${_sharingStatus.value}`;
+    // Collapse published versions of a dataset to the latest one
+    queryUrl += `&latest_versions=true`;
     // Structured filters (chips) become dedicated query parameters...
     for (const token of _searchTokens.value) {
         queryUrl += `&${token.type}=${encodeURIComponent(token.value)}`;
@@ -190,7 +192,7 @@ watch([_searchTerm, _searchTokens], () => {
 });
 
 function createSurface() {
-    axios.post('/manager/api/surface/').then(response => {
+    axios.post('/manager/v2/surface/').then(response => {
         window.location.href = `/ui/dataset-detail/${response.data.id}/`;
     });
 }


### PR DESCRIPTION
Phase 1 of the performance work: the dataset list moves off the unoptimized v1 endpoints onto v2, and stored-file URLs become stable so browsers can actually cache thumbnails, plot data and deep-zoom tiles.

**Deploy order:** requires ContactEngineering/topobank-rest-api#17 and ContactEngineering/topobank-publication#51 — the list page consumes the embedded summaries those PRs add to the v2 surface response.

## Dataset list on v2

`DatasetList` fetches `/manager/v2/surface/`, whose response now embeds everything a row shows: creator name (`created_by.name`), a publication summary (DOI, license, authors, download route) and per-measurement summaries with thumbnail URLs. Each row used to fire 2–3 XHRs of its own (creator, publication, measurements-for-thumbnails) against v1 endpoints costing ~8–10 queries per measurement server-side; those requests also queued ahead of the thumbnail images on the browser's 6-connections-per-host budget, which is where the 1–5 s thumbnail delay came from. A page is now exactly one API request.

Sorting maps to v2 `order` parameters, the version collapse to `latest_versions=true`, and dataset creation goes through v2 (which now names unnamed datasets like v1 did). `SelectionOffcanvas` reads selected datasets from v2 as well. The "Created by you" / "shared with you" badges render again — they relied on a `sharing_status` field that no API version reported until now. Two legacy badge blocks (`publication_doi`/`publication_license`) referenced fields that never existed in any response and are removed.

## Browser-cacheable file URLs

`ce_ui.storage.CachedPresignedUrlStorage` memoizes presigned URLs in Redis for half their lifetime, so consecutive responses hand out the *same* URL and repeat visits hit the browser cache instead of re-downloading every thumbnail, series file and tile. Files in the data lake are immutable (replacement means a new manifest under a new path), so a memoized URL can never point at stale content. Uploaded objects also carry a matching `Cache-Control: private, max-age=…` header.

One property worth noting for review: a signed URL is already a bearer token valid for its full lifetime regardless of later permission changes; memoization doesn't extend that window (`AWS_QUERYSTRING_EXPIRE`, default 24 h since #306), it only reuses it.

## Testing

- `vitest run`: 178 tests pass
- `webpack --mode development` compiles with only the pre-existing sass warnings
- Python changes syntax-checked; the Django suite runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY)_