### PR TITLE
Dataset detail page renders from the v2 API (phase 1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog for plugin *ce-ui*
 
+## 1.37.0 (2026-08-04)
+
+- ENH: The dataset detail page is server-rendered from the v2 API, which does
+  not inline full measurement representations; rendering the page costs a
+  handful of database queries instead of ~10 per measurement. The measurement
+  cards fetch their data asynchronously, so the page paints immediately
+- ENH: The publication details of a published dataset arrive embedded in the
+  v2 response instead of requiring a separate request before anything renders
+- ENH: The permissions tab runs on the v2 permission-set API
+  (grant/revoke endpoints) instead of the v1 whole-list PATCH
+- BUG: Tag badges on the dataset detail sidebar rendered empty (they read
+  `.name` off what has always been a plain string)
+
 ## 1.36.0 (2026-08-04)
 
 - ENH: The dataset list runs on the v2 API and renders each page from a single

--- a/ce_ui/views.py
+++ b/ce_ui/views.py
@@ -23,6 +23,7 @@ from topobank_publication.serializers import PublicationCollectionSerializer
 from topobank_rest_api.analysis.serializers import WorkflowDetailSerializer
 from topobank_rest_api.manager.v1.serializers import (SurfaceSerializer,
                                                       TopographySerializer)
+from topobank_rest_api.manager.v2.serializers import SurfaceV2Serializer
 
 from ce_ui import breadcrumb
 from ce_ui.publication_metadata import publication_metadata
@@ -95,9 +96,32 @@ class DataSetListView(AppView):
 class DatasetDetailView(AppDetailView):
     model = Surface
     vue_component = "DatasetDetail"
-    serializer_class = SurfaceSerializer
+    # The v2 serializer does not inline full measurement representations (the
+    # page fetches those asynchronously), so rendering this page costs a
+    # handful of queries instead of ~10 per measurement.
+    serializer_class = SurfaceV2Serializer
     # Extends app.html and adds server-rendered metadata to its head
     template_name = "dataset_detail.html"
+
+    def get_queryset(self):
+        # Everything the v2 serializer touches, so serialization does not
+        # degenerate into per-relation queries
+        qs = Surface.objects.select_related(
+            "permissions",
+            "created_by",
+            "updated_by",
+            "owned_by",
+            "attachments",
+        ).prefetch_related(
+            "topography_set__thumbnail",
+            "properties",
+            "tags",
+            "permissions__user_permissions__user",
+        )
+        if hasattr(Surface, "publication"):
+            # Only present when the publication plugin is installed
+            qs = qs.select_related("publication")
+        return qs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/frontend/components/manager/DatasetPermissions.vue
+++ b/frontend/components/manager/DatasetPermissions.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 
 import axios from "axios";
-import {ref} from "vue";
+import {computed, onMounted, ref} from "vue";
 
 import {
     BAlert,
@@ -14,30 +14,69 @@ import {
 import SearchUserModal from "@/components/ui/SearchUserModal.vue";
 import PermissionRow from "@/components/manager/PermissionRow.vue";
 import Toolbar from "@/components/ui/Toolbar.vue";
+import LoadingIndicator from '@/components/ui/LoadingIndicator.vue';
 
 const {show} = useToastController();
 
 const props = defineProps({
-    setPermissionsUrl: String,
-    permissions: Object
+    // v2 permission-set endpoint of the dataset
+    permissionsUrl: String
 });
-
-const emit = defineEmits([
-    'update:permissions'
-]);
 
 const isEditing = ref(false);
 const isSaving = ref(false);
-const selfPermissions = ref(props.permissions);
-const savedPermissions = ref(props.permissions);
 const searchUser = ref(false);
+
+/* Rows in the shape PermissionRow works on: {user: <url>, permission: <level>}.
+   The current user's row is read-only; the others can be edited with full
+   access. */
+const _api = ref(null);  // grant/revoke routes reported by the permission set
+const currentUser = ref(null);
+const otherUsers = ref([]);
+const savedOtherUsers = ref([]);
+
+onMounted(loadPermissions);
+
+function loadPermissions() {
+    axios.get(props.permissionsUrl).then(response => {
+        _api.value = response.data.api;
+        const rows = response.data.user_permissions.map(p => {
+            return {user: p.user.url, permission: p.allow, isCurrentUser: p.is_current_user};
+        });
+        currentUser.value = rows.find(row => row.isCurrentUser) ?? null;
+        otherUsers.value = rows.filter(row => !row.isCurrentUser);
+    }).catch(error => {
+        show?.({
+            props: {
+                title: "Failed to fetch permissions",
+                body: error,
+                variant: 'danger'
+            }
+        });
+    });
+}
+
+const hasFullAccess = computed(() => {
+    return currentUser.value?.permission === 'full';
+});
 
 function saveCard() {
     isEditing.value = false;
     isSaving.value = true;
-    axios.patch(props.setPermissionsUrl, selfPermissions.value.other_users).then(response => {
-        emit('update:permissions', response.data);
-    }).catch(error => {
+    // Grant changed access levels; a row set to 'no-access' is a revocation
+    const saved = new Map(savedOtherUsers.value.map(row => [row.user, row.permission]));
+    const requests = [];
+    for (const row of otherUsers.value) {
+        if (saved.get(row.user) === row.permission) {
+            continue;  // unchanged
+        }
+        if (row.permission === 'no-access') {
+            requests.push(axios.post(_api.value.revoke_user_access, {user: row.user}));
+        } else {
+            requests.push(axios.post(_api.value.grant_user_access, {user: row.user, allow: row.permission}));
+        }
+    }
+    Promise.all(requests).catch(error => {
         show?.({
             props: {
                 title: "Permission update failed",
@@ -45,22 +84,24 @@ function saveCard() {
                 variant: 'danger'
             }
         });
-        selfPermissions.value = savedPermissions.value;
     }).finally(() => {
+        // Re-read the authoritative state, whether saving succeeded or not
+        loadPermissions();
         isSaving.value = false;
     });
 }
 
 function addUser(user) {
     searchUser.value = false;
-    selfPermissions.value.other_users.push({user: user.url, permission: 'view'});
+    otherUsers.value.push({user: user.url, permission: 'view'});
 }
 
 </script>
 
 <template>
-    <div>
-        <Toolbar v-if="selfPermissions.current_user.permission === 'full'">
+    <LoadingIndicator v-if="currentUser == null"/>
+    <div v-if="currentUser != null">
+        <Toolbar v-if="hasFullAccess">
             <BButtonGroup v-if="isEditing || isSaving"
                           class="me-2"
                           size="sm">
@@ -74,7 +115,7 @@ function addUser(user) {
                 v-if="!isEditing && !isSaving"
                 size="sm">
                 <BButton variant="primary"
-                         @click="savedPermissions = JSON.parse(JSON.stringify(selfPermissions)); isEditing = true">
+                         @click="savedOtherUsers = JSON.parse(JSON.stringify(otherUsers)); isEditing = true">
                     <i class="fa fa-pen me-1"></i>Edit
                 </BButton>
             </BButtonGroup>
@@ -82,7 +123,7 @@ function addUser(user) {
                           size="sm">
                 <BButton v-if="isEditing"
                          variant="danger"
-                         @click="isEditing = false; selfPermissions = savedPermissions">
+                         @click="isEditing = false; otherUsers = savedOtherUsers">
                     Discard
                 </BButton>
                 <BButton variant="success"
@@ -98,16 +139,16 @@ function addUser(user) {
             modify measurements; <b>Full</b> can additionally publish and manage
             who has access.
         </BAlert>
-        <PermissionRow :user-permission="selfPermissions.current_user"
+        <PermissionRow :user-permission="currentUser"
                        :disabled="true">
         </PermissionRow>
         <hr/>
-        <div v-if="selfPermissions.other_users.length === 0">
+        <div v-if="otherUsers.length === 0">
             Only you can access this digital surface twin.
         </div>
-        <PermissionRow v-if="selfPermissions.other_users.length > 0"
-                       v-for="(userPermission, index) in selfPermissions.other_users"
-                       v-model:user-permission="selfPermissions.other_users[index]"
+        <PermissionRow v-if="otherUsers.length > 0"
+                       v-for="(userPermission, index) in otherUsers"
+                       v-model:user-permission="otherUsers[index]"
                        :disabled="!isEditing">
         </PermissionRow>
     </div>

--- a/frontend/pages/DatasetDetail.vue
+++ b/frontend/pages/DatasetDetail.vue
@@ -66,10 +66,10 @@ const attachmentCount = ref(null);  // default count of the attachments
 const propertyCount = ref(null);  // default count of the properties
 
 // Data that is displayed or can be edited
-const _surface = shallowRef(null);  // Surface data
+const _surface = shallowRef(null);  // Surface data (v2 representation)
 const _publication = ref(null);  // Publication data
-const _permissions = ref(null);  // Permissions
 const _topographies = ref([]);  // Topographies contained in this surface
+const _loadingTopographies = ref(false);  // Measurements are fetched asynchronously
 const _versions = ref(null);  // Published versions of this surface
 
 // GUI logic
@@ -103,20 +103,54 @@ function getOriginalSurfaceId() {
 }
 
 function updateCard() {
-    /* Fetch JSON describing the card */
+    /* The server renders the v2 surface representation into the page; the
+       full measurement representations that the cards work on are fetched
+       asynchronously, so first paint does not wait for them. */
     _surface.value = appProps.object;
-    _permissions.value = appProps.object.permissions;
-    _topographies.value = appProps.object.topography_set;
-    _selected.value = new Array(_topographies.value.length).fill(false);  // Nothing is selected
+    fetchTopographies();
     updatePublication();
 }
 
+async function fetchTopographies() {
+    _loadingTopographies.value = true;
+    try {
+        const topographies = [];
+        // The endpoint may paginate; follow `next` until the list is complete
+        let url = `/manager/api/topography/?surface=${appProps.object.id}&limit=100`;
+        while (url != null) {
+            const response = await axios.get(url);
+            if (Array.isArray(response.data)) {
+                topographies.push(...response.data);
+                url = null;
+            } else {
+                topographies.push(...response.data.results);
+                url = response.data.next;
+            }
+        }
+        _topographies.value = topographies;
+        _selected.value = new Array(topographies.length).fill(false);  // Nothing is selected
+    } catch (error) {
+        show?.({
+            props: {
+                title: "Failed to fetch measurements",
+                body: error,
+                variant: 'danger'
+            }
+        });
+    } finally {
+        _loadingTopographies.value = false;
+    }
+}
+
 function updatePublication() {
+    /* The v2 representation embeds a compact publication summary; the full
+       record (citation formats, publisher) is only needed on this page and
+       only for published datasets. */
     if (_surface.value.publication == null) {
         _publication.value = null;
         updateVersions();
     } else {
-        axios.get(_surface.value.publication).then(response => {
+        axios.get(_surface.value.publication.url).then(response => {
             _publication.value = response.data;
             updateVersions();
         }).catch(error => {
@@ -153,7 +187,9 @@ function filesDropped(files) {
 
 function uploadNewTopography(file) {
     axios.post(props.newTopographyUrl, {
-        surface: _surface.value.url,
+        // The v1 create endpoint validates `surface` against the v1 route, so
+        // the URL is constructed here rather than taken from the v2 object
+        surface: `/manager/api/surface/${_surface.value.id}/`,
         name: file.name
     }).then(response => {
         let upload = response.data;
@@ -262,12 +298,18 @@ const publishUrl = computed(() => {
     return `/ui/dataset-publish/${getSurfaceId()}/`;
 });
 
+// The current user's access level; the v2 representation reports it as
+// `permissions.allow`
+const permission = computed(() => {
+    return _surface.value?.permissions?.allow ?? 'view';
+});
+
 const isEditable = computed(() => {
-    return _surface.value != null && _surface.value.permissions.current_user.permission !== 'view';
+    return _surface.value != null && permission.value !== 'view';
 });
 
 const hasFullAccess = computed(() => {
-    return _surface.value != null && _surface.value.permissions.current_user.permission === 'full';
+    return _surface.value != null && permission.value === 'full';
 });
 
 const isPublication = computed(() => {
@@ -337,6 +379,7 @@ const measurementCount = computed(() => {
                         </Toolbar>
                         <DropZone v-if="isEditable" @files-dropped="filesDropped">
                         </DropZone>
+                        <LoadingIndicator v-if="_loadingTopographies"/>
                         <!-- Left accent bar (primary) plus alternating row
                              background visually separate each measurement. -->
                         <div v-for="(topography, index) in _topographies"
@@ -386,7 +429,8 @@ const measurementCount = computed(() => {
                         </BModal>
                     </BTab>
                     <BTab id="dataset-bandwidths" title="Bandwidths">
-                        <BAlert :model-value="_topographies.length == 0" variant="secondary">
+                        <LoadingIndicator v-if="_loadingTopographies"/>
+                        <BAlert :model-value="!_loadingTopographies && _topographies.length == 0" variant="secondary">
                             <i class="fa-solid fa-circle-info me-2"></i>This surface has no measurements.
                         </BAlert>
                         <BAlert :model-value="_topographies.length > 0"
@@ -409,7 +453,7 @@ const measurementCount = computed(() => {
                         <DatasetDescription v-if="_surface != null"
                                             :description="_surface.description"
                                             :name="_surface.name"
-                                            :permission="_permissions.current_user.permission"
+                                            :permission="permission"
                                             :surface-url="_surface.url"
                                             :tags="_surface.tags">
                         </DatasetDescription>
@@ -420,7 +464,7 @@ const measurementCount = computed(() => {
                         </template>
                         <DatasetProperties v-if="_surface != null"
                                            v-model:properties="_surface.properties"
-                                           :permission="_permissions.current_user.permission"
+                                           :permission="permission"
                                            :surface-url="_surface.url"
                                            v-model:propertyCount="propertyCount">
                         </DatasetProperties>
@@ -433,8 +477,8 @@ const measurementCount = computed(() => {
                             Attachments <BBadge>{{ attachmentCount }}</BBadge>
                         </template>
                         <Attachments v-if="_surface != null"
-                                     :attachments-url="_surface.attachments"
-                                     :permission="_permissions.current_user.permission"
+                                     :attachments-url="_surface.attachments?.url"
+                                     :permission="permission"
                                      v-model:attachmentCount="attachmentCount">
                         </Attachments>
                     </BTab>
@@ -442,8 +486,7 @@ const measurementCount = computed(() => {
                           v-if="_surface != null"
                           title="Permissions">
                         <DatasetPermissions v-if="_surface.publication == null"
-                                            v-model:permissions="_permissions"
-                                            :set-permissions-url="_surface.api.set_permissions">
+                                            :permissions-url="_surface.permissions.url">
                         </DatasetPermissions>
                         <BAlert v-if="_surface.publication != null"
                                 :model-value="true" variant="secondary">
@@ -489,7 +532,7 @@ const measurementCount = computed(() => {
                             </div>
                             <div v-if="_surface.tags.length > 0">
                                 <span v-for="tag in _surface.tags"
-                                      class="badge bg-success">{{ tag.name }}</span>
+                                      class="badge bg-success">{{ tag }}</span>
                             </div>
                             <BDropdown
                                 v-if="_versions == null || _versions.length > 0"


### PR DESCRIPTION
Phase 1b of the performance work: the dataset detail page moves off the server-rendered v1 serializer.

**Deploy order:** best together with ContactEngineering/topobank-rest-api#18 (the async measurement fetch hits the v1 topography list, which that PR makes cheap). Nothing breaks without it — it's just slower.

## What changed

**Server render is v2 and O(1).** `DatasetDetailView` used to serialize the full v1 surface into the page, inlining every measurement at ~10 queries each — time to first byte grew linearly with dataset size (the biggest published datasets have 50+ measurements). It now renders the v2 representation from a prefetched queryset: a handful of queries regardless of size, with the publication summary embedded (the page no longer fetches the publication before rendering the sidebar; the full record with citation formats is only fetched for published datasets).

**Measurements stream in.** The page paints immediately; the measurement cards fetch their full v1 representations asynchronously (with a pagination-following loop) and keep their existing shape — the upload, polling, and edit flows in `TopographyCard`/`TopographyUpdateCard` are untouched. Uploads still create through v1, whose create endpoint validates `surface` against the v1 route, so that URL is constructed explicitly.

**Permissions tab on v2.** `DatasetPermissions` reads the user list from the v2 permission-set endpoint and saves through its grant/revoke routes, sending only the rows that changed, instead of PATCHing the whole `other_users` list to the v1 `set_permissions` route. `PermissionRow` is unchanged.

**Behavioral notes for review:**
- Deleting a dataset now goes through v2, which *soft*-deletes (`lazy_delete`) instead of the v1 hard delete. Notifications to sharers are sent either way.
- Tag badges on the detail sidebar rendered empty since they read `.name` off what has always been a plain string — fixed.
- `permissions.allow` (v2) replaces `permissions.current_user.permission` (v1) as the edit/full-access gate.

## Testing

- `vitest run`: 178 tests pass
- `webpack --mode development` compiles with only pre-existing sass warnings
- Django suite runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY)_