### PR TITLE
Analysis cards poll task states in one batched request (phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for plugin *ce-ui*
 
+## 1.38.0 (2026-08-04)
+
+- ENH: Analysis cards poll the task states of all their pending analyses in a
+  single batched request per tick (v2 `ids` filter) instead of one request per
+  analysis every few seconds — running a workflow over a dataset with dozens
+  of measurements no longer floods the server with polling traffic
+- ENH: The task-status rows share a cache for workflow and subject
+  descriptions, so opening the task list of a card makes one request for the
+  workflow instead of one per row
+
 ## 1.37.0 (2026-08-04)
 
 - ENH: The dataset detail page is server-rendered from the v2 API, which does

--- a/frontend/components/analysis/TaskStateRow.vue
+++ b/frontend/components/analysis/TaskStateRow.vue
@@ -1,7 +1,28 @@
+<script lang="ts">
+import axios from "axios";
+
+/* Task states are polled in one batched request per card (see TasksButton);
+   this row only displays them. It still fetches the workflow and subject
+   descriptions for its header - through a cache shared by all rows (module
+   scope, not per instance), since every row of a card asks for the same
+   workflow, and rows for the same subject repeat too. */
+const _sharedInfoCache = new Map();
+
+function cachedGet(url) {
+    if (!_sharedInfoCache.has(url)) {
+        _sharedInfoCache.set(url, axios.get(url).then(response => response.data).catch(error => {
+            // Do not cache failures
+            _sharedInfoCache.delete(url);
+            throw error;
+        }));
+    }
+    return _sharedInfoCache.get(url);
+}
+</script>
+
 <script setup lang="ts">
 
-import axios from "axios";
-import {computed, onMounted, onBeforeUnmount, ref, watch} from "vue";
+import {computed, ref, watch} from "vue";
 
 import {BButton, useToastController} from "bootstrap-vue-next";
 
@@ -13,52 +34,19 @@ const {show} = useToastController();
 
 const analysis = defineModel('analysis', {required: true});
 
-const props = defineProps({
-    pollingInterval: {
-        type: Number,
-        default: 5000  // milliseconds
-    },
-    maxPollingInterval: {
-        type: Number,
-        default: 30000  // milliseconds
-    }
-});
-
 const _error = ref(null);
 const _function = ref(null);
 const _subject = ref(null);
-let _timeoutID = null;
 
-/* Poll quickly at first, then back off: short tasks report promptly, while a
-   long-running task is not hammered with a request every few seconds by every
-   open row. Reset when the user renews the task. */
-let _currentPollingInterval = props.pollingInterval;
-
-onMounted(() => {
-    scheduleStateCheck();
-});
-
-onBeforeUnmount(() => {
-    if (_timeoutID != null) {
-        clearTimeout(_timeoutID);
-        _timeoutID = null;
-    }
-});
-
-function scheduleStateCheck() {
-    // Tasks are still pending or running if this state check is scheduled
-
-    // Get function information if we don't have it yet
-    if (_function.value == null) {
-        axios.get(analysis.value.function)
-            .then(response => {
-                _function.value = response.data;
-            }).catch(error => {
+function fetchInfo() {
+    if (_function.value == null && analysis.value.function != null) {
+        cachedGet(analysis.value.function).then(data => {
+            _function.value = data;
+        }).catch(error => {
             show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
         });
     }
 
-    // Get subject information if we don't have it yet
     if (_subject.value == null) {
         const subject = analysis.value.subject;
         const subjectUrl = subject.topography != null ?
@@ -67,38 +55,8 @@ function scheduleStateCheck() {
         if (subjectUrl == null) {
             show?.({props: {title: "Error", body: "Unable to determine subject for analysis", variant: 'danger'}});
         } else {
-            axios.get(subjectUrl)
-                .then(response => {
-                    _subject.value = response.data;
-                }).catch(error => {
-                show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
-            });
-        }
-    }
-
-    if (analysis.value.task_state == null || analysis.value.task_state === 'pe' || analysis.value.task_state === 'st') {
-        if (_timeoutID == null) {
-            _timeoutID = setTimeout(checkState, _currentPollingInterval);
-            _currentPollingInterval = Math.min(
-                _currentPollingInterval * 1.5, props.maxPollingInterval);
-        }
-    } else if (analysis.value.task_state === 'fa') {
-        // This is a failure. Query reason.
-        if (analysis.value.task_error) {
-            // The analysis function failed and we have an error message (Python exception).
-            _error.value = analysis.value.task_error;
-        } else {
-            // The analysis function did not raise an exception itself. This means it actually finished and
-            // we have a result.json, that should contain an error message.
-            axios.get(analysis.value.folder).then(response => {
-                const resultFile = response.data["result.json"];
-                if (resultFile?.url != null) {
-                    axios.get(resultFile.url).then(response => {
-                        _error.value = response.data.message;
-                    }).catch(error => {
-                        show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
-                    });
-                }
+            cachedGet(subjectUrl).then(data => {
+                _subject.value = data;
             }).catch(error => {
                 show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
             });
@@ -106,22 +64,34 @@ function scheduleStateCheck() {
     }
 }
 
-function checkState() {
-    _timeoutID = null;  // Indicate that no timer is currently running
-    axios.get(analysis.value.url).then(response => {
-        // Update current state of the analysis
-        analysis.value = response.data;  // This will trigger a check throw a watch
-    }).catch(error => {
-        show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
-    });
+function fetchFailureReason() {
+    if (analysis.value.task_error) {
+        // The analysis function failed and we have an error message (Python exception).
+        _error.value = analysis.value.task_error;
+    } else {
+        // The analysis function did not raise an exception itself. This means it actually finished and
+        // we have a result.json, that should contain an error message.
+        axios.get(analysis.value.folder).then(response => {
+            const resultFile = response.data["result.json"];
+            if (resultFile?.url != null) {
+                axios.get(resultFile.url).then(response => {
+                    _error.value = response.data.message;
+                }).catch(error => {
+                    show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
+                });
+            }
+        }).catch(error => {
+            show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
+        });
+    }
 }
 
 function renew() {
-    _currentPollingInterval = props.pollingInterval;
-    analysis.value.task_state = 'pe';
+    analysis.value.task_state = 'pe';  // The batched poller in TasksButton picks this up
+    _error.value = null;
     // A PUT request triggers renewal of the analysis
     axios.put(analysis.value.url).then(response => {
-        analysis.value = response.data;  // This will trigger a check throw a watch
+        analysis.value = response.data;
     }).catch(error => {
         show?.({props: {title: "Request failed", body: error, variant: 'danger'}});
     });
@@ -136,8 +106,11 @@ const creationTimePretty = computed(() => formatDateTime(analysis.value.creation
 const startTimePretty = computed(() => formatDateTime(analysis.value.task_start_time));
 
 watch(() => analysis.value, () => {
-    scheduleStateCheck();
-});
+    fetchInfo();
+    if (analysis.value.task_state === 'fa' && _error.value == null) {
+        fetchFailureReason();
+    }
+}, {immediate: true});
 
 </script>
 

--- a/frontend/components/analysis/TasksButton.vue
+++ b/frontend/components/analysis/TasksButton.vue
@@ -1,6 +1,7 @@
 <script setup>
 
-import {computed, ref, watch} from "vue";
+import axios from "axios";
+import {computed, onBeforeUnmount, ref, watch} from "vue";
 
 import {BButton} from 'bootstrap-vue-next';
 
@@ -14,12 +15,111 @@ const analyses = defineModel('analyses', {required: true});
 // Event when all tasks are finished
 const emit = defineEmits(['allTasksFinished', 'someTasksFinished']);
 
+const props = defineProps({
+    pollingInterval: {
+        type: Number,
+        default: 5000  // milliseconds
+    },
+    maxPollingInterval: {
+        type: Number,
+        default: 30000  // milliseconds
+    }
+});
+
 // UI logic
 const _modalVisible = ref(false);
 
 // Number of running or pending tasks
 const nbRunningOrPending = computed(() => {
     return countTaskStates(analyses.value, ['pe', 'st', 're']);
+});
+
+/* Batched task polling: while any task of this card is pending or running, the
+   task states of all of them are fetched in a single request per tick, rather
+   than every task polling its own detail route (which meant one request per
+   analysis every few seconds during a bulk run). Poll quickly at first, then
+   back off; the backoff resets whenever a drained card picks up new pending
+   tasks (e.g. the user renews one). */
+
+// Task fields the poll merges into the analyses. Everything else keeps the
+// shape the card endpoint delivered, so displays bound to it are unaffected.
+const TASK_FIELDS = [
+    'task_state',
+    'task_progress',
+    'task_messages',
+    'task_error',
+    'task_traceback',
+    'task_memory',
+    'task_duration',
+    'task_submission_time',
+    'task_start_time',
+    'task_end_time'
+];
+
+// The endpoint caps `limit` at this value; poll in chunks
+const MAX_BATCH_SIZE = 100;
+
+let _timeoutID = null;
+let _currentPollingInterval = props.pollingInterval;
+
+function pendingIds() {
+    if (analyses.value == null) {
+        return [];
+    }
+    return analyses.value
+        .filter(a => a != null && ['pe', 'st', 're'].includes(a.task_state))
+        .map(a => a.id);
+}
+
+async function poll() {
+    _timeoutID = null;
+    const ids = pendingIds();
+    if (ids.length === 0) {
+        return;
+    }
+    try {
+        const updated = new Map();
+        for (let start = 0; start < ids.length; start += MAX_BATCH_SIZE) {
+            const chunk = ids.slice(start, start + MAX_BATCH_SIZE);
+            const response = await axios.get(
+                `/analysis/v2/results/?ids=${chunk.join(',')}&limit=${chunk.length}`);
+            for (const result of response.data.results ?? response.data) {
+                updated.set(result.id, result);
+            }
+        }
+        analyses.value = analyses.value.map(analysis => {
+            const update = updated.get(analysis?.id);
+            if (update == null) {
+                return analysis;
+            }
+            const merged = {...analysis};
+            for (const field of TASK_FIELDS) {
+                if (field in update) {
+                    merged[field] = update[field];
+                }
+            }
+            return merged;
+        });
+    } catch (error) {
+        // Transient failure; the next tick retries
+    }
+    scheduleNextPoll();
+}
+
+function scheduleNextPoll() {
+    if (pendingIds().length === 0 || _timeoutID != null) {
+        return;
+    }
+    _timeoutID = setTimeout(poll, _currentPollingInterval);
+    _currentPollingInterval = Math.min(
+        _currentPollingInterval * 1.5, props.maxPollingInterval);
+}
+
+onBeforeUnmount(() => {
+    if (_timeoutID != null) {
+        clearTimeout(_timeoutID);
+        _timeoutID = null;
+    }
 });
 
 // Tell the parent when tasks finish. A watcher only fires when the count
@@ -32,7 +132,14 @@ watch(nbRunningOrPending, (current, previous) => {
             emit('someTasksFinished', current);
         }
     }
-});
+    if (current > 0) {
+        if (previous == null || previous === 0) {
+            // A fresh batch of tasks: start polling promptly again
+            _currentPollingInterval = props.pollingInterval;
+        }
+        scheduleNextPoll();
+    }
+}, {immediate: true});
 
 // Number of successful tasks
 const nbSuccess = computed(() => {


### PR DESCRIPTION
Phase 2 of the performance work — the analysis pages, which were the original complaint (PSD/ACF cards during bulk runs).

**Deploy order:** requires ContactEngineering/topobank-rest-api#19 (the `ids` filter the batched poll uses).

## What changed

**One poll request per card per tick.** Every pending analysis used to poll its own v1 detail route every 5–30 s: a workflow running over a dataset with 50 measurements meant 50 polling requests per tick, each costing a full v1 serialization server-side. `TasksButton` — which every card type routes through (`SeriesCard`, `RoughnessParametersCard`, `ContactMechanicsCard`) — now polls `/analysis/v2/results/?ids=…` once per tick for all pending analyses of the card and merges the returned task fields into the card's analyses. Only task fields are merged, so everything else keeps the shape the card endpoint delivered and all existing displays are unaffected.

**Same behavior, fraction of the traffic.** The 5 s → 30 s exponential backoff, the backoff reset when a drained card picks up new pending tasks (e.g. renew), and the `someTasksFinished`/`allTasksFinished` events (which drive the throttled card refresh) are preserved exactly. Renew stays a single v1 PUT.

**Task rows stop making per-row requests.** Rows no longer poll; their workflow/subject descriptions go through a module-level promise cache, so opening the task list of a card makes one request for the workflow (previously one per row — the workflow URL is identical for every row of a card) and one per distinct subject. Failure-reason lookup (result.json) is unchanged.

Together with phase 1's presigned-URL memoization (series data is now browser-cacheable across card refreshes), this addresses the analysis-page load pattern end to end: fewer polls, cheaper polls, cached series fetches.

## Testing

- `vitest run`: 178 tests pass
- `webpack --mode development` compiles with only pre-existing sass warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY)_