### PR TITLE
Fix coverage measurement, then raise both halves above 80% with functional tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,14 @@ jobs:
           git+https://github.com/ContactEngineering/topobank-statistics.git@main \
           git+https://github.com/ContactEngineering/topobank-contact.git@main \
           git+https://github.com/ContactEngineering/topobank-publication.git@main \
-          git+https://github.com/ContactEngineering/topobank-orcid.git@main \
-          .[dev]
+          git+https://github.com/ContactEngineering/topobank-orcid.git@main
+        # Installed editable on purpose: `pytest.ini` sets
+        # `--import-mode=importlib` and does not put the repository root on
+        # `sys.path`, so a copied (non-editable) install means the tests import
+        # `ce_ui` from site-packages while coverage measures the source tree
+        # here -- which never executes, and reported every application module as
+        # 0%. An editable install leaves exactly one copy of the code.
+        pip install -e '.[dev]'
 
     - name: Test
       run: PYTHONPATH=/tmp/topobank pytest -v --cov=ce_ui --cov-report=term --cov-report=xml

--- a/ce_ui/tests/test_analysis_views.py
+++ b/ce_ui/tests/test_analysis_views.py
@@ -25,8 +25,13 @@ PASSWORD = "abcd$1234"
 
 
 @pytest.fixture
-def analyst(db, client, django_user_model):
-    """A logged-in user, past the terms-and-conditions gate."""
+def analyst(db, client, django_user_model, orcid_socialapp):
+    """A logged-in user, past the terms-and-conditions gate.
+
+    `orcid_socialapp` is required because the base template renders an ORCID
+    login link, which raises `SocialApp.DoesNotExist` when no social app is
+    configured -- so every test that renders a page needs it, signed in or not.
+    """
     user = django_user_model.objects.create_user(
         username="analyst", password=PASSWORD
     )

--- a/ce_ui/tests/test_analysis_views.py
+++ b/ce_ui/tests/test_analysis_views.py
@@ -1,0 +1,248 @@
+"""Tests for the analysis pages and the subject handling they rely on.
+
+Two behaviours matter here beyond the pages rendering at all:
+
+* which extra breadcrumb tabs open for a given selection, which is what lets a
+  user get back to the dataset they came from, and
+* that a `subjects` parameter which cannot be decoded is ignored rather than
+  raising, since the parameter travels in URLs that get shared and edited.
+"""
+
+import pytest
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+from topobank.analysis.models import Workflow
+from topobank.manager.utils import subjects_to_base64
+from topobank.testing.factories import SurfaceFactory, Topography1DFactory
+
+from ce_ui.views import (_safe_subjects_from_request,
+                         extra_tabs_if_single_item_selected)
+
+#: Registered by the repository's `conftest.py`.
+WORKFLOW = "topobank.testing.test"
+
+PASSWORD = "abcd$1234"
+
+
+@pytest.fixture
+def analyst(db, client, django_user_model):
+    """A logged-in user, past the terms-and-conditions gate."""
+    user = django_user_model.objects.create_user(
+        username="analyst", password=PASSWORD
+    )
+    user.user_permissions.add(Permission.objects.get(codename="can_skip_terms"))
+    assert client.login(username="analyst", password=PASSWORD)
+    return user
+
+
+def tab_titles(context):
+    return [tab["title"] for tab in context["extra_tabs"]]
+
+
+#
+# Which tabs open for a selection
+#
+
+
+@pytest.mark.django_db
+def test_a_single_measurement_opens_its_dataset_and_itself():
+    surface = SurfaceFactory()
+    topography = Topography1DFactory(surface=surface)
+    context = {}
+
+    extra_tabs_if_single_item_selected(context, [topography])
+
+    assert tab_titles(context) == [surface.label, topography.name]
+    assert [tab["href"] for tab in context["extra_tabs"]] == [
+        reverse("ce_ui:surface-detail", kwargs={"pk": surface.pk}),
+        reverse("ce_ui:topography-detail", kwargs={"pk": topography.pk}),
+    ]
+    # Neither is the current page; the analysis tab added afterwards is
+    assert not any(tab["active"] for tab in context["extra_tabs"])
+
+
+@pytest.mark.django_db
+def test_a_single_dataset_opens_only_the_dataset():
+    surface = SurfaceFactory()
+    context = {}
+
+    extra_tabs_if_single_item_selected(context, [surface])
+
+    assert tab_titles(context) == [surface.label]
+
+
+@pytest.mark.django_db
+def test_a_dataset_with_its_own_measurements_opens_the_dataset():
+    surface = SurfaceFactory()
+    topographies = [Topography1DFactory(surface=surface) for _ in range(2)]
+    context = {}
+
+    extra_tabs_if_single_item_selected(context, [surface, *topographies])
+
+    # The measurements belong to the selected dataset, so it is still a single
+    # subject as far as the breadcrumbs are concerned
+    assert tab_titles(context) == [surface.label]
+
+
+@pytest.mark.django_db
+def test_a_measurement_from_another_dataset_opens_nothing():
+    surface = SurfaceFactory()
+    foreign = Topography1DFactory(surface=SurfaceFactory())
+    context = {}
+
+    extra_tabs_if_single_item_selected(context, [surface, foreign])
+
+    # The selection spans two datasets, so there is no single one to link to
+    assert context.get("extra_tabs", []) == []
+
+
+@pytest.mark.django_db
+def test_several_datasets_open_nothing():
+    context = {}
+
+    extra_tabs_if_single_item_selected(
+        context, [SurfaceFactory(), SurfaceFactory()]
+    )
+
+    assert context.get("extra_tabs", []) == []
+
+
+def test_an_empty_selection_opens_nothing():
+    context = {}
+
+    extra_tabs_if_single_item_selected(context, [])
+
+    assert context.get("extra_tabs", []) == []
+
+
+#
+# Decoding the `subjects` parameter
+#
+
+
+@pytest.mark.django_db
+def test_subjects_are_decoded_from_the_parameter(rf, analyst):
+    topography = Topography1DFactory(surface=SurfaceFactory(created_by=analyst))
+    request = rf.get(
+        "/ui/analysis-list/", {"subjects": subjects_to_base64([topography])}
+    )
+    request.user = analyst
+
+    subjects = _safe_subjects_from_request(request)
+
+    assert [subject.pk for subject in subjects] == [topography.pk]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "value",
+    ["", "not base64 at all!!", "aGVsbG8=", "e30="],
+    ids=["empty", "not-base64", "base64-but-not-json", "json-but-not-subjects"],
+)
+def test_an_undecodable_parameter_selects_nothing(rf, analyst, value):
+    request = rf.get("/ui/analysis-list/", {"subjects": value})
+    request.user = analyst
+
+    # These URLs get shared and hand-edited, so a broken one must not be a 500
+    assert _safe_subjects_from_request(request) == []
+
+
+@pytest.mark.django_db
+def test_a_missing_parameter_selects_nothing(rf, analyst):
+    request = rf.get("/ui/analysis-list/")
+    request.user = analyst
+
+    assert _safe_subjects_from_request(request) == []
+
+
+#
+# The pages
+#
+
+
+@pytest.mark.django_db
+def test_analysis_list_page_offers_the_analyze_tab(client, analyst):
+    response = client.get(reverse("ce_ui:results-list"))
+
+    assert response.status_code == 200
+    current = response.context["extra_tabs"][-1]
+    assert current["title"] == "Analyze"
+    assert current["active"] is True
+    # The basket lets the selection be changed from this page
+    assert current["show_basket"] is True
+
+
+@pytest.mark.django_db
+def test_analysis_list_page_opens_tabs_for_the_selected_measurement(client, analyst):
+    surface = SurfaceFactory(created_by=analyst)
+    topography = Topography1DFactory(surface=surface)
+
+    response = client.get(
+        reverse("ce_ui:results-list"),
+        {"subjects": subjects_to_base64([topography])},
+    )
+
+    assert response.status_code == 200
+    assert tab_titles(response.context) == [
+        surface.label,
+        topography.name,
+        "Analyze",
+    ]
+
+
+@pytest.mark.django_db
+def test_analysis_list_page_ignores_a_broken_selection(client, analyst):
+    response = client.get(
+        reverse("ce_ui:results-list"), {"subjects": "not base64 at all!!"}
+    )
+
+    assert response.status_code == 200
+    assert tab_titles(response.context) == ["Analyze"]
+
+
+@pytest.mark.django_db
+def test_workflow_page_names_the_workflow(client, analyst):
+    response = client.get(
+        reverse("ce_ui:results-detail", kwargs={"slug": WORKFLOW})
+    )
+
+    assert response.status_code == 200
+    tabs = response.context["extra_tabs"]
+    # Back to all results, then the workflow being looked at
+    assert tabs[-2]["title"] == "Analyze"
+    assert tabs[-1]["title"] == Workflow(name=WORKFLOW).display_name
+    assert tabs[-1]["active"] is True
+
+
+@pytest.mark.django_db
+def test_workflow_page_opens_tabs_for_the_selected_measurement(client, analyst):
+    surface = SurfaceFactory(created_by=analyst)
+    topography = Topography1DFactory(surface=surface)
+
+    response = client.get(
+        reverse("ce_ui:results-detail", kwargs={"slug": WORKFLOW}),
+        {"subjects": subjects_to_base64([topography])},
+    )
+
+    assert response.status_code == 200
+    assert tab_titles(response.context)[:2] == [surface.label, topography.name]
+
+
+@pytest.mark.django_db
+def test_an_unknown_workflow_is_not_found(client, analyst):
+    response = client.get(
+        reverse("ce_ui:results-detail", kwargs={"slug": "nosuch.workflow"})
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_a_workflow_the_user_may_not_run_is_forbidden(client, analyst, monkeypatch):
+    monkeypatch.setattr("ce_ui.views.get_workflow_names", lambda user=None: [])
+
+    response = client.get(
+        reverse("ce_ui:results-detail", kwargs={"slug": WORKFLOW})
+    )
+
+    assert response.status_code == 403

--- a/ce_ui/tests/test_breadcrumb.py
+++ b/ce_ui/tests/test_breadcrumb.py
@@ -1,0 +1,118 @@
+"""Tests for the breadcrumb navigation tabs.
+
+The interesting part is `add_topography`, which links to the previous and next
+measurement of the *same* dataset so that they can be stepped through from the
+detail page.
+"""
+
+import pytest
+from django.urls import reverse
+from topobank.testing.factories import SurfaceFactory, Topography1DFactory
+
+from ce_ui import breadcrumb
+
+
+def titles(context):
+    return [tab["title"] for tab in context["extra_tabs"]]
+
+
+def test_context_without_tabs_gets_a_tab_list():
+    context = {}
+
+    breadcrumb.prepare_context(context)
+
+    assert context["extra_tabs"] == []
+
+
+def test_adding_a_tab_deactivates_the_ones_before_it():
+    context = {"extra_tabs": [{"title": "Datasets", "active": True}]}
+
+    breadcrumb.add_generic(context, {"title": "Analyze", "active": True})
+
+    # Only the tab added last is the current one
+    assert [tab["active"] for tab in context["extra_tabs"]] == [False, True]
+    assert titles(context) == ["Datasets", "Analyze"]
+
+
+@pytest.mark.django_db
+def test_dataset_tab_points_at_the_dataset():
+    surface = SurfaceFactory()
+    context = {}
+
+    breadcrumb.add_surface(context, surface)
+
+    (tab,) = context["extra_tabs"]
+    assert tab["title"] == surface.label
+    assert tab["href"] == reverse("ce_ui:surface-detail", kwargs={"pk": surface.pk})
+    assert tab["active"] is True
+    assert tab["login_required"] is False
+
+
+@pytest.mark.django_db
+def test_measurement_tab_links_to_both_neighbours():
+    surface = SurfaceFactory()
+    first, middle, last = (Topography1DFactory(surface=surface) for _ in range(3))
+    context = {}
+
+    breadcrumb.add_topography(context, middle)
+
+    (tab,) = context["extra_tabs"]
+    assert tab["title"] == middle.name
+    assert tab["href"] == reverse(
+        "ce_ui:topography-detail", kwargs={"pk": middle.pk}
+    )
+    assert tab["href_previous"] == reverse(
+        "ce_ui:topography-detail", kwargs={"pk": first.pk}
+    )
+    assert tab["href_next"] == reverse(
+        "ce_ui:topography-detail", kwargs={"pk": last.pk}
+    )
+
+
+@pytest.mark.django_db
+def test_first_measurement_has_no_previous_and_last_has_no_next():
+    surface = SurfaceFactory()
+    first, _, last = (Topography1DFactory(surface=surface) for _ in range(3))
+
+    first_context = {}
+    breadcrumb.add_topography(first_context, first)
+    last_context = {}
+    breadcrumb.add_topography(last_context, last)
+
+    (first_tab,) = first_context["extra_tabs"]
+    (last_tab,) = last_context["extra_tabs"]
+    assert "href_previous" not in first_tab
+    assert "href_next" in first_tab
+    assert "href_next" not in last_tab
+    assert "href_previous" in last_tab
+
+
+@pytest.mark.django_db
+def test_a_lone_measurement_has_no_neighbours():
+    topography = Topography1DFactory(surface=SurfaceFactory())
+    context = {}
+
+    breadcrumb.add_topography(context, topography)
+
+    (tab,) = context["extra_tabs"]
+    assert "href_next" not in tab
+    assert "href_previous" not in tab
+
+
+@pytest.mark.django_db
+def test_neighbours_never_come_from_another_dataset():
+    surface = SurfaceFactory()
+    other_surface = SurfaceFactory()
+    first = Topography1DFactory(surface=surface)
+    # Created in between, so its primary key falls between the two measurements
+    # of `surface`: stepping through must skip it regardless.
+    Topography1DFactory(surface=other_surface)
+    second = Topography1DFactory(surface=surface)
+
+    context = {}
+    breadcrumb.add_topography(context, first)
+
+    (tab,) = context["extra_tabs"]
+    assert tab["href_next"] == reverse(
+        "ce_ui:topography-detail", kwargs={"pk": second.pk}
+    )

--- a/ce_ui/tests/test_storage.py
+++ b/ce_ui/tests/test_storage.py
@@ -1,0 +1,181 @@
+"""Tests for the presigned-URL memoizing storage backend.
+
+The point of `CachedPresignedUrlStorage` is that the URL for one stored object
+does not change on every request, because a URL that changes can never be
+served from the browser cache. These tests therefore check what the *caller*
+observes -- the same URL string, produced by a single signature -- rather than
+the internals of the cache.
+
+No S3 is involved: the parent's signing method is replaced by one that returns a
+different URL every time it is called, so a repeated signature is detectable.
+"""
+
+import pytest
+from storages.backends.s3boto3 import S3Boto3Storage
+
+from ce_ui.storage import CachedPresignedUrlStorage
+
+#: A day, matching the `AWS_QUERYSTRING_EXPIRE` default.
+ONE_DAY = 86400
+
+
+class RecordingCache:
+    """Stands in for the Django cache, keeping the timeouts it was given."""
+
+    def __init__(self):
+        self.values = {}
+        self.timeouts = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.timeouts[key] = timeout
+
+
+@pytest.fixture
+def signatures(monkeypatch):
+    """Replace the parent's signing with a counter, and report the calls."""
+    calls = []
+
+    def fake_url(self, name, parameters=None, expire=None, http_method=None):
+        calls.append(
+            {
+                "name": name,
+                "parameters": parameters,
+                "expire": expire,
+                "http_method": http_method,
+            }
+        )
+        # A real presigned URL differs on every signature; so does this one.
+        return f"https://s3.invalid/{name}?signature={len(calls)}"
+
+    monkeypatch.setattr(S3Boto3Storage, "url", fake_url)
+    return calls
+
+
+@pytest.fixture
+def cache(monkeypatch):
+    recording = RecordingCache()
+    monkeypatch.setattr("ce_ui.storage.cache", recording)
+    return recording
+
+
+def make_storage(location="media", querystring_expire=ONE_DAY, querystring_auth=True):
+    """A storage instance configured without touching S3 or the settings.
+
+    Only `url()` is under test and it reads exactly these three attributes, so
+    the instance is built without running the boto3-backed constructor.
+    """
+    storage = CachedPresignedUrlStorage.__new__(CachedPresignedUrlStorage)
+    storage.location = location
+    storage.querystring_expire = querystring_expire
+    storage.querystring_auth = querystring_auth
+    return storage
+
+
+def test_the_same_object_keeps_the_same_url(signatures, cache):
+    storage = make_storage()
+
+    first = storage.url("thumbnails/1.png")
+    second = storage.url("thumbnails/1.png")
+
+    # One signature, handed out twice: this is what lets a browser reuse what it
+    # already downloaded.
+    assert first == second
+    assert len(signatures) == 1
+
+
+def test_each_object_gets_its_own_url(signatures, cache):
+    storage = make_storage()
+
+    first = storage.url("thumbnails/1.png")
+    second = storage.url("thumbnails/2.png")
+
+    assert first != second
+    assert len(signatures) == 2
+    # ...and the first one is still served from the cache afterwards
+    assert storage.url("thumbnails/1.png") == first
+    assert len(signatures) == 2
+
+
+def test_url_is_cached_for_half_its_lifetime(signatures, cache):
+    storage = make_storage(querystring_expire=ONE_DAY)
+
+    storage.url("thumbnails/1.png")
+
+    (timeout,) = cache.timeouts.values()
+    # Half, so that a URL handed out at the end of the window is still valid for
+    # at least the other half of its lifetime.
+    assert timeout == ONE_DAY // 2
+
+
+def test_very_short_lived_urls_are_still_cached_briefly(signatures, cache):
+    storage = make_storage(querystring_expire=10)
+
+    storage.url("thumbnails/1.png")
+
+    (timeout,) = cache.timeouts.values()
+    # A floor keeps the cache useful when the signature lifetime is tiny; the
+    # URL may then outlive its own validity, which is why the floor is low.
+    assert timeout == 60
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"parameters": {"ResponseContentDisposition": "attachment"}},
+        {"expire": 30},
+        {"http_method": "PUT"},
+    ],
+    ids=["parameters", "expire", "http_method"],
+)
+def test_requests_asking_for_something_special_are_signed_fresh(
+    signatures, cache, kwargs
+):
+    storage = make_storage()
+
+    storage.url("thumbnails/1.png", **kwargs)
+    storage.url("thumbnails/1.png", **kwargs)
+
+    # A download-with-filename or an upload URL is not the plain object URL, so
+    # it must neither be served from nor written to the cache.
+    assert len(signatures) == 2
+    assert cache.values == {}
+    # The request is forwarded unchanged
+    for key, value in kwargs.items():
+        assert signatures[0][key] == value
+
+
+def test_a_special_request_does_not_evict_the_plain_url(signatures, cache):
+    storage = make_storage()
+    plain = storage.url("thumbnails/1.png")
+
+    storage.url("thumbnails/1.png", parameters={"ResponseContentType": "image/png"})
+
+    assert storage.url("thumbnails/1.png") == plain
+
+
+def test_public_buckets_are_left_alone(signatures, cache):
+    storage = make_storage(querystring_auth=False)
+
+    storage.url("thumbnails/1.png")
+    storage.url("thumbnails/1.png")
+
+    # An unsigned URL is already stable, so there is nothing to memoize
+    assert cache.values == {}
+    assert len(signatures) == 2
+
+
+def test_two_prefixes_do_not_share_a_url(signatures, cache):
+    media = make_storage(location="media")
+    other = make_storage(location="other")
+
+    from_media = media.url("thumbnails/1.png")
+    from_other = other.url("thumbnails/1.png")
+
+    # Same name under a different prefix is a different object; if the cache key
+    # ignored the prefix, one would be served the other's URL.
+    assert from_media != from_other
+    assert len(signatures) == 2

--- a/frontend/stores/analysis.test.ts
+++ b/frontend/stores/analysis.test.ts
@@ -1,0 +1,73 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {createPinia, setActivePinia} from "pinia";
+
+import {useAnalysisStore} from "@/stores/analysis";
+
+const PSD = "topobank_statistics.power_spectral_density";
+const ACF = "topobank_statistics.autocorrelation";
+
+describe("useAnalysisStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("starts with no workflow selected", () => {
+        const analysis = useAnalysisStore();
+
+        expect(analysis.workflows).toEqual([]);
+        expect(analysis.isSelected(PSD)).toBe(false);
+    });
+
+    it("remembers which workflows are to be shown", () => {
+        const analysis = useAnalysisStore();
+
+        analysis.select(PSD);
+        analysis.select(ACF);
+
+        expect(analysis.workflows).toEqual([PSD, ACF]);
+        expect(analysis.isSelected(PSD)).toBe(true);
+        expect(analysis.isSelected(ACF)).toBe(true);
+    });
+
+    it("removes only the workflow that was unselected", () => {
+        const analysis = useAnalysisStore();
+        analysis.select(PSD);
+        analysis.select(ACF);
+
+        analysis.unselect(PSD);
+
+        expect(analysis.workflows).toEqual([ACF]);
+        expect(analysis.isSelected(PSD)).toBe(false);
+        expect(analysis.isSelected(ACF)).toBe(true);
+    });
+
+    it("ignores unselecting a workflow that was never selected", () => {
+        const analysis = useAnalysisStore();
+        analysis.select(PSD);
+
+        analysis.unselect(ACF);
+
+        expect(analysis.workflows).toEqual([PSD]);
+    });
+
+    it("drops every workflow on clear", () => {
+        const analysis = useAnalysisStore();
+        analysis.select(PSD);
+        analysis.select(ACF);
+
+        analysis.clear();
+
+        expect(analysis.workflows).toEqual([]);
+        expect(analysis.isSelected(ACF)).toBe(false);
+    });
+
+    it("does not confuse workflows whose names share a prefix", () => {
+        const analysis = useAnalysisStore();
+
+        analysis.select("topobank_statistics.height_distribution");
+
+        // `includes` matches whole entries, not substrings
+        expect(analysis.isSelected("topobank_statistics.height")).toBe(false);
+        expect(analysis.isSelected("topobank_statistics.height_distribution")).toBe(true);
+    });
+});

--- a/frontend/stores/datasetSelection.test.ts
+++ b/frontend/stores/datasetSelection.test.ts
@@ -1,0 +1,110 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {createPinia, setActivePinia} from "pinia";
+
+import {useDatasetSelectionStore} from "@/stores/datasetSelection";
+
+/** A dataset as the list endpoint returns it, reduced to what the store keeps. */
+function dataset(id: number, name = `Dataset ${id}`) {
+    return {id, name, url: `/manager/v2/surface/${id}/`};
+}
+
+describe("useDatasetSelectionStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("starts empty", () => {
+        const selection = useDatasetSelectionStore();
+
+        expect(selection.datasetIds).toEqual([]);
+        expect(selection.nbSelected).toBe(0);
+        expect(selection.isSelected(1)).toBe(false);
+    });
+
+    it("remembers the datasets that were selected", () => {
+        const selection = useDatasetSelectionStore();
+
+        selection.select(dataset(7));
+        selection.select(dataset(9));
+
+        expect(selection.datasetIds).toEqual([7, 9]);
+        expect(selection.nbSelected).toBe(2);
+        expect(selection.isSelected(7)).toBe(true);
+        expect(selection.isSelected(8)).toBe(false);
+    });
+
+    it("keeps the full dataset so a selected row needs no refetch", () => {
+        const selection = useDatasetSelectionStore();
+
+        selection.select(dataset(7, "Steel sample"));
+
+        expect(selection.getDataset(7)).toMatchObject({id: 7, name: "Steel sample"});
+        expect(selection.getDataset(8)).toBeUndefined();
+    });
+
+    it("forgets both the id and the cached dataset when one is unselected", () => {
+        const selection = useDatasetSelectionStore();
+        selection.select(dataset(7));
+        selection.select(dataset(9));
+
+        selection.unselect(7);
+
+        expect(selection.datasetIds).toEqual([9]);
+        expect(selection.isSelected(7)).toBe(false);
+        // The cache is pruned as well, so a long session cannot grow it without
+        // bound
+        expect(selection.getDataset(7)).toBeUndefined();
+        expect(selection.getDataset(9)).toMatchObject({id: 9});
+    });
+
+    it("leaves the selection alone when unselecting something not in it", () => {
+        const selection = useDatasetSelectionStore();
+        selection.select(dataset(7));
+
+        selection.unselect(42);
+
+        expect(selection.datasetIds).toEqual([7]);
+        expect(selection.getDataset(7)).toMatchObject({id: 7});
+    });
+
+    it("drops everything on clear", () => {
+        const selection = useDatasetSelectionStore();
+        selection.select(dataset(7));
+        selection.select(dataset(9));
+
+        selection.clear();
+
+        expect(selection.datasetIds).toEqual([]);
+        expect(selection.nbSelected).toBe(0);
+        expect(selection.getDataset(7)).toBeUndefined();
+    });
+
+    it("renders the selection as the comma-separated ids the download route takes", () => {
+        const selection = useDatasetSelectionStore();
+
+        selection.select(dataset(3));
+        expect(selection.selectedAsString).toBe("3");
+
+        selection.select(dataset(5));
+        selection.select(dataset(11));
+        // `/manager/v2/download-surface/<ids>/` is built from this
+        expect(selection.selectedAsString).toBe("3,5,11");
+    });
+
+    it("encodes the selection as the subjects payload the analysis page decodes", () => {
+        const selection = useDatasetSelectionStore();
+        selection.select(dataset(3));
+        selection.select(dataset(5));
+
+        const decoded = JSON.parse(atob(selection.selectedAsBase64));
+
+        expect(decoded).toEqual({surface: [3, 5]});
+    });
+
+    it("encodes an empty selection without failing", () => {
+        const selection = useDatasetSelectionStore();
+
+        expect(JSON.parse(atob(selection.selectedAsBase64))).toEqual({surface: []});
+        expect(selection.selectedAsString).toBe("");
+    });
+});

--- a/frontend/utils/paginatedList.test.ts
+++ b/frontend/utils/paginatedList.test.ts
@@ -1,6 +1,284 @@
-import {describe, expect, it} from "vitest";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {nextTick} from "vue";
 
-import {formatBytes, formatTimestamp} from "@/utils/paginatedList";
+const {mockGet} = vi.hoisted(() => ({mockGet: vi.fn()}));
+
+vi.mock("axios", () => ({
+    default: {
+        get: mockGet,
+        // The composable asks axios whether a rejection is an abort; mirror
+        // that with a marker the tests can attach.
+        isCancel: (error: any) => error?.__cancel === true
+    }
+}));
+
+import {formatBytes, formatTimestamp, usePaginatedList} from "@/utils/paginatedList";
+
+/** A promise whose settlement the test controls, standing in for a request. */
+function deferred() {
+    let resolve!: (value: any) => void;
+    let reject!: (error: any) => void;
+    const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return {promise, resolve, reject};
+}
+
+/** Let the composable's `.then`/`.catch` handler run before asserting.
+ *
+ * Both handlers are attached to `promise` before this one, so FIFO ordering of
+ * the microtask queue guarantees they have run once this resolves.
+ */
+async function settled(promise: Promise<any>) {
+    await promise.catch(() => undefined);
+    await nextTick();
+}
+
+/** The query string of the n-th request the composable issued. */
+function requestUrl(index: number): string {
+    return mockGet.mock.calls[index][0] as string;
+}
+
+describe("usePaginatedList", () => {
+    beforeEach(() => {
+        mockGet.mockReset();
+        mockGet.mockReturnValue(deferred().promise);
+        // The composable registers `onBeforeUnmount`, which warns when it is
+        // called outside a component instance. Exercising it directly is the
+        // point here, so the expected warning is silenced rather than printed.
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it("requests the slice that the offset asks for", () => {
+        const list = usePaginatedList("/api/things");
+
+        list.load(50);
+
+        expect(mockGet).toHaveBeenCalledTimes(1);
+        expect(requestUrl(0)).toContain("offset=50");
+        expect(requestUrl(0)).toContain("limit=25");
+        // Third page of 25, counted from one, is what the pager displays
+        expect(list.currentPage.value).toBe(3);
+        expect(list.isLoading.value).toBe(true);
+    });
+
+    it("translates a page number into an offset", () => {
+        const list = usePaginatedList("/api/things", {pageSize: 10});
+
+        list.goToPage(4);
+
+        expect(requestUrl(0)).toContain("offset=30");
+        expect(requestUrl(0)).toContain("limit=10");
+        expect(list.currentPage.value).toBe(4);
+    });
+
+    it("publishes the rows and the total from the response", async () => {
+        const request = deferred();
+        mockGet.mockReturnValue(request.promise);
+        const list = usePaginatedList("/api/things");
+
+        list.load();
+        request.resolve({data: {results: [{id: 1}, {id: 2}], count: 7}});
+        await settled(request.promise);
+
+        expect(list.items.value).toEqual([{id: 1}, {id: 2}]);
+        expect(list.count.value).toBe(7);
+        expect(list.isLoading.value).toBe(false);
+        expect(list.errorMessage.value).toBeNull();
+    });
+
+    it("omits ordering and search when there is nothing to send", () => {
+        const list = usePaginatedList("/api/things");
+
+        list.load();
+
+        expect(requestUrl(0)).not.toContain("ordering");
+        expect(requestUrl(0)).not.toContain("search");
+    });
+
+    it("sends the ordering it was configured with", () => {
+        const list = usePaginatedList("/api/things", {ordering: "name"});
+
+        list.load();
+
+        expect(requestUrl(0)).toContain("ordering=name");
+    });
+
+    it("flips the direction when the same column is sorted twice", () => {
+        const list = usePaginatedList("/api/things", {ordering: "name"});
+
+        list.sortBy("name");
+        expect(list.ordering.value).toBe("-name");
+        expect(requestUrl(0)).toContain("ordering=-name");
+
+        list.sortBy("name");
+        expect(list.ordering.value).toBe("name");
+        expect(requestUrl(1)).toContain("ordering=name");
+    });
+
+    it("starts ascending when a different column is sorted", () => {
+        const list = usePaginatedList("/api/things", {ordering: "-name"});
+
+        list.sortBy("size");
+
+        expect(list.ordering.value).toBe("size");
+        expect(requestUrl(0)).toContain("ordering=size");
+    });
+
+    it("appends extra parameters, repeating keys for list values", () => {
+        const list = usePaginatedList("/api/things", {
+            extraParams: () => ({task_state: ["pe", "st"], kind: "task"})
+        });
+
+        list.load();
+
+        const url = requestUrl(0);
+        expect(url).toContain("task_state=pe");
+        expect(url).toContain("task_state=st");
+        expect(url).toContain("kind=task");
+    });
+
+    it("coalesces a burst of keystrokes into a single request", async () => {
+        vi.useFakeTimers();
+        const list = usePaginatedList("/api/things", {searchDelay: 300});
+
+        for (const term of ["a", "ab", "abc"]) {
+            list.searchTerm.value = term;
+            await nextTick();
+        }
+        expect(mockGet).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(300);
+
+        expect(mockGet).toHaveBeenCalledTimes(1);
+        expect(requestUrl(0)).toContain("search=abc");
+    });
+
+    it("searches for the trimmed term, and not at all for blank input", async () => {
+        vi.useFakeTimers();
+        const list = usePaginatedList("/api/things", {searchDelay: 300});
+
+        list.searchTerm.value = "  steel  ";
+        await nextTick();
+        vi.advanceTimersByTime(300);
+        expect(requestUrl(0)).toContain("search=steel");
+
+        list.searchTerm.value = "   ";
+        await nextTick();
+        vi.advanceTimersByTime(300);
+        expect(requestUrl(1)).not.toContain("search=");
+    });
+
+    it("reloads when the page size changes", async () => {
+        const list = usePaginatedList("/api/things");
+
+        list.pageSize.value = 50;
+        await nextTick();
+
+        expect(mockGet).toHaveBeenCalledTimes(1);
+        expect(requestUrl(0)).toContain("limit=50");
+    });
+
+    it("aborts the request still in flight", () => {
+        const signals: AbortSignal[] = [];
+        mockGet.mockImplementation((_url: string, config: any) => {
+            signals.push(config.signal);
+            return deferred().promise;
+        });
+        const list = usePaginatedList("/api/things");
+
+        list.load(0);
+        list.load(25);
+
+        expect(signals[0].aborted).toBe(true);
+        expect(signals[1].aborted).toBe(false);
+    });
+
+    it("never lets a superseded response overwrite a newer one", async () => {
+        const first = deferred();
+        const second = deferred();
+        mockGet.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+        const list = usePaginatedList("/api/things");
+
+        list.load(0);
+        list.load(25);
+
+        second.resolve({data: {results: [{id: "current"}], count: 1}});
+        await settled(second.promise);
+        expect(list.items.value).toEqual([{id: "current"}]);
+
+        // The first request comes back late; its rows are stale by now.
+        first.resolve({data: {results: [{id: "stale"}], count: 99}});
+        await settled(first.promise);
+
+        expect(list.items.value).toEqual([{id: "current"}]);
+        expect(list.count.value).toBe(1);
+    });
+
+    it("reports the error detail the server sent", async () => {
+        const request = deferred();
+        mockGet.mockReturnValue(request.promise);
+        const list = usePaginatedList("/api/things");
+
+        list.load();
+        request.reject({response: {data: {detail: "Not allowed to list users."}}});
+        await settled(request.promise);
+
+        expect(list.errorMessage.value).toBe("Not allowed to list users.");
+        expect(list.isLoading.value).toBe(false);
+    });
+
+    it("stays quiet when a request was aborted rather than failed", async () => {
+        const request = deferred();
+        mockGet.mockReturnValue(request.promise);
+        const list = usePaginatedList("/api/things");
+
+        list.load();
+        request.reject({__cancel: true});
+        await settled(request.promise);
+
+        // An abort is the composable's own doing, not something to show a user
+        expect(list.errorMessage.value).toBeNull();
+    });
+
+    it("does not report an error from a request that was superseded", async () => {
+        const first = deferred();
+        const second = deferred();
+        mockGet.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+        const list = usePaginatedList("/api/things");
+
+        list.load(0);
+        list.load(25);
+        first.reject({response: {data: {detail: "stale failure"}}});
+        await settled(first.promise);
+
+        expect(list.errorMessage.value).toBeNull();
+    });
+
+    it("clears a previous error once a request succeeds", async () => {
+        const failing = deferred();
+        const succeeding = deferred();
+        mockGet.mockReturnValueOnce(failing.promise).mockReturnValueOnce(succeeding.promise);
+        const list = usePaginatedList("/api/things");
+
+        list.load();
+        failing.reject({response: {data: {detail: "boom"}}});
+        await settled(failing.promise);
+        expect(list.errorMessage.value).toBe("boom");
+
+        list.load();
+        succeeding.resolve({data: {results: [], count: 0}});
+        await settled(succeeding.promise);
+
+        expect(list.errorMessage.value).toBeNull();
+    });
+});
 
 describe("formatBytes", () => {
     it("scales to a readable unit", () => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,5 +90,16 @@ packages = ["ce_ui"]
 force-include = { "package.json" = "ce_ui/package.json" }
 
 [tool.coverage.run]
-# Generated migration modules would dilute the coverage numbers
-omit = ["*/migrations/*"]
+omit = [
+    # Generated migration modules would dilute the coverage numbers
+    "*/migrations/*",
+    # The test suite covering itself says nothing about the application
+    "*/tests/*",
+    # Deployment-time modules that a test run never executes: the suite runs
+    # under `ce_ui.settings.test`, and nothing imports the ASGI entry point.
+    # Counting them is a permanent deduction that hides real gaps rather than
+    # pointing at anything actionable.
+    "*/ce_ui/settings/local.py",
+    "*/ce_ui/settings/production.py",
+    "*/ce_ui/asgi.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,10 +96,11 @@ omit = [
     # The test suite covering itself says nothing about the application
     "*/tests/*",
     # Deployment-time modules that a test run never executes: the suite runs
-    # under `ce_ui.settings.test`, and nothing imports the ASGI entry point.
+    # under `ce_ui.settings.test`, and nothing imports the server entry points.
     # Counting them is a permanent deduction that hides real gaps rather than
     # pointing at anything actionable.
     "*/ce_ui/settings/local.py",
     "*/ce_ui/settings/production.py",
     "*/ce_ui/asgi.py",
+    "*/ce_ui/wsgi.py",
 ]


### PR DESCRIPTION
Raises test coverage in this repo to the 80% target. Two parts: first make the number mean something, then close the real gaps it exposes.

## Part 1 — the 34% was a measurement bug, not a coverage gap

`pytest.ini` sets `--import-mode=importlib` and leaves `pythonpath = .` commented out, so nothing puts the repository root on `sys.path`. `import ce_ui` therefore resolved to the copy that a non-editable `pip install .[dev]` leaves in site-packages — while `--cov=ce_ui` resolved to the local `ce_ui/` directory, which never executes. Every application module reported 0%, including `settings/base.py`, which obviously does run. Of 1120 statements, the 378 counted as covered were almost exactly the test modules; pytest loads *those* by file path, so they were the only thing measured.

Concretely: `views.py` was never untested — `test_prevent_url_guessing` and `test_anonymous` exercise `DatasetDetailView`.

The fix is an editable install in CI, so exactly one copy of the code exists. Verified locally that this works with this `pyproject.toml`: `ce_ui.__file__` resolves to the source tree, and the `force-include`d `package.json` is still resolvable, because `ce_ui.bokehjs` already documents and handles the source-checkout case via its repository-root fallback — so `test_bokehjs_version` and the `checks.py` staleness check are unaffected.

Coverage also now omits what made the number less informative: the **test modules** (self-coverage, and previously the entire total) and the **deployment-only modules** a test run cannot execute (`settings/local.py`, `settings/production.py`, `asgi.py`, `wsgi.py`) — ~90 permanently unreachable statements that hid real gaps.

That alone moved the Python figure from a meaningless 34% to a real **80%**, with no test changes.

## Part 2 — functional tests for what was actually uncovered

These assert behaviour, not reachability.

**`ce_ui/storage.py`: 0% → 100%.** The presigned-URL memoization from #307, the one genuine gap Part 1 exposed. Tests cover that one object keeps one URL across calls (the whole point — a URL that changes cannot be served from the browser cache), that the entry lives for half the signature lifetime with a floor, that download- and upload-flavoured requests are signed fresh *and never evict the plain URL*, that public buckets are left alone, and that two prefixes cannot be served each other's URL.

**`ce_ui/breadcrumb.py`: 57% → 100%.** That a measurement tab links to the previous and next measurement of the same dataset, that the ends of the list have only one neighbour, and that a measurement of *another* dataset is never offered as a neighbour even when its primary key falls in between — the case the `surface=` filter exists for.

**`ce_ui/views.py`: 67% → 82%.** The full branch matrix of `extra_tabs_if_single_item_selected` (single measurement, single dataset, dataset with its own measurements, measurement of a foreign dataset, several datasets, nothing selected); that a `subjects` parameter which cannot be decoded is ignored rather than raising, in four flavours of broken input, since these URLs get shared and hand-edited; and that the analysis pages render their tabs, 404 an unknown workflow and 403 one the user may not run.

**`usePaginatedList`: 18% → 95%.** Request parameters and pagination arithmetic, a burst of keystrokes collapsing into one request, the request in flight being aborted (asserted on the `AbortSignal`), and above all that **a superseded response can never overwrite a newer one** or report a stale error — the race the composable exists to prevent.

**The Pinia stores: 0% → covered.** Membership, that unselecting prunes the cached dataset as well as the id (the unbounded-growth contract), and the two encodings other pages consume: the comma-separated ids of the download route and the base64 subjects payload the analysis page decodes, checked by round-trip.

## Result

| | Before | After |
|---|---|---|
| Python | 34% *(meaningless)* → 80% *(measured)* | **90%** |
| Frontend (TS) | 73.9% | **87.04%** |
| Python tests | 57 | **93** |
| Frontend tests | 178 | **210** |

Both halves are above the 80% target. `storage.py` and `breadcrumb.py` are at 100%; the largest remaining gap is `views.py` at 82% (46 statements, mostly the terms-and-conditions and user-profile views).

Suggested follow-up, once this settles: add `--cov-fail-under` a couple of points below the achieved figures and ratchet it, so the number cannot quietly regress.

## Note for review

`.vue` components remain unmeasured — 10,804 lines of them, versus 1,922 lines of TypeScript. Instrumenting them needs `@vitejs/plugin-vue` + `jsdom` + `@vue/test-utils`, none currently installed, and is a separate project; the frontend figure above describes the TypeScript logic modules only.

Unrelated finding, not addressed here: `select`/`unselect` in `DatasetList.vue` are dead code — never referenced in the template, since the checkbox binds `selection.datasetIds` directly — so `datasetCache` is never populated in the list flow and `SelectionOffcanvas` refetches each dataset by id anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWTwYfvS1aEyuhGr2VkfY